### PR TITLE
feat: CascadeFusion strategy for hybrid retrieval

### DIFF
--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -23,7 +23,7 @@ use std::collections::{HashMap, HashSet};
 
 pub use bm25::{BM25Result, BM25Retriever, Document as BM25Document};
 pub use enriched::{EnrichedRetrievalConfig, EnrichedRetriever};
-pub use hybrid::{FusionMethod, HybridConfig, HybridRetriever, HybridSearchResult};
+pub use hybrid::{CascadeConfig, FusionMethod, HybridConfig, HybridRetriever, HybridSearchResult};
 
 #[cfg(feature = "pagerank")]
 pub use pagerank_retrieval::{PageRankRetrievalSystem, ScoredResult};


### PR DESCRIPTION
## Summary
- Adds Cascade variant to FusionMethod enum
- CascadeConfig with score_threshold, cheap_k, expensive_k
- Runs BM25 first, escalates to vector if scores below threshold

Refs: issue #27 (Epic 2, Story 2.2)
Supersedes: #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)