### PR TITLE
feat: config-driven PipelineBuilder

### DIFF
--- a/graphrag-core/src/builder/mod.rs
+++ b/graphrag-core/src/builder/mod.rs
@@ -1,6 +1,7 @@
 //! GraphRAG builder module
 //!
-//! This module provides a builder pattern for constructing GraphRAG instances.
+//! This module provides a builder pattern for constructing GraphRAG instances
+//! and a config-driven `PipelineBuilder` for chaining `Stage<I,O>` objects.
 
 use crate::core::{GraphRAGError, Result};
 
@@ -36,3 +37,260 @@ impl GraphRAG {
         GraphRAGBuilder::new()
     }
 }
+
+// ============================================================================
+// Pipeline Builder
+// ============================================================================
+
+#[cfg(feature = "async")]
+mod pipeline_builder {
+    use crate::config::Config;
+    use crate::core::{GraphRAGError, Result};
+    use crate::pipeline::stage::Stage;
+    use async_trait::async_trait;
+    use std::fmt;
+
+    /// A type-erased pipeline step that transforms `Vec<u8>` (serialized) input/output.
+    /// This enables heterogeneous stage chaining in a single pipeline.
+    #[async_trait]
+    trait ErasedStage: Send + Sync {
+        async fn process_erased(&self, input: Vec<u8>) -> Result<Vec<u8>>;
+        fn name(&self) -> &str;
+    }
+
+    /// Wraps a concrete `Stage<I,O>` into an erased stage using serde.
+    struct TypedStageWrapper<S, I, O> {
+        stage: S,
+        _phantom: std::marker::PhantomData<(I, O)>,
+    }
+
+    // Manual Send+Sync: safe because PhantomData doesn't hold data
+    unsafe impl<S: Send, I, O> Send for TypedStageWrapper<S, I, O> {}
+    unsafe impl<S: Sync, I, O> Sync for TypedStageWrapper<S, I, O> {}
+
+    #[async_trait]
+    impl<S, I, O> ErasedStage for TypedStageWrapper<S, I, O>
+    where
+        S: Stage<I, O> + Send + Sync,
+        I: serde::de::DeserializeOwned + Send + 'static,
+        O: serde::Serialize + Send + 'static,
+    {
+        async fn process_erased(&self, input: Vec<u8>) -> Result<Vec<u8>> {
+            let decoded: I = serde_json::from_slice(&input).map_err(|e| {
+                GraphRAGError::Config {
+                    message: format!("Pipeline stage input deserialization failed: {e}"),
+                }
+            })?;
+            let output = self.stage.process(decoded).await?;
+            serde_json::to_vec(&output).map_err(|e| GraphRAGError::Config {
+                message: format!("Pipeline stage output serialization failed: {e}"),
+            })
+        }
+
+        fn name(&self) -> &str {
+            self.stage.name()
+        }
+    }
+
+    /// A built pipeline that processes data through a chain of stages.
+    pub struct Pipeline {
+        stages: Vec<Box<dyn ErasedStage>>,
+        config_snapshot: String,
+    }
+
+    impl fmt::Debug for Pipeline {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let names: Vec<&str> = self.stages.iter().map(|s| s.name()).collect();
+            f.debug_struct("Pipeline")
+                .field("stages", &names)
+                .finish()
+        }
+    }
+
+    impl Pipeline {
+        /// Run the pipeline with a serializable input, returning serialized output.
+        pub async fn run<I, O>(&self, input: I) -> Result<O>
+        where
+            I: serde::Serialize + Send + 'static,
+            O: serde::de::DeserializeOwned + Send + 'static,
+        {
+            if self.stages.is_empty() {
+                return Err(GraphRAGError::Config {
+                    message: "Pipeline has no stages".to_string(),
+                });
+            }
+
+            let mut data = serde_json::to_vec(&input).map_err(|e| GraphRAGError::Config {
+                message: format!("Pipeline input serialization failed: {e}"),
+            })?;
+
+            for stage in &self.stages {
+                data = stage.process_erased(data).await?;
+            }
+
+            serde_json::from_slice(&data).map_err(|e| GraphRAGError::Config {
+                message: format!("Pipeline output deserialization failed: {e}"),
+            })
+        }
+
+        /// Get the number of stages in the pipeline.
+        pub fn stage_count(&self) -> usize {
+            self.stages.len()
+        }
+
+        /// Get the effective config snapshot (for `--print-effective-config`).
+        pub fn effective_config(&self) -> &str {
+            &self.config_snapshot
+        }
+
+        /// Get the names of all stages in order.
+        pub fn stage_names(&self) -> Vec<&str> {
+            self.stages.iter().map(|s| s.name()).collect()
+        }
+    }
+
+    /// Config-driven builder that chains `Stage<I,O>` objects into a `Pipeline`.
+    pub struct PipelineBuilder {
+        stages: Vec<Box<dyn ErasedStage>>,
+        config: Config,
+    }
+
+    impl PipelineBuilder {
+        /// Create a new pipeline builder with the given config.
+        pub fn new(config: Config) -> Self {
+            Self {
+                stages: Vec::new(),
+                config,
+            }
+        }
+
+        /// Add a typed stage to the pipeline.
+        ///
+        /// Stages are executed in the order they are added.
+        pub fn add_stage<S, I, O>(mut self, stage: S) -> Self
+        where
+            S: Stage<I, O> + Send + Sync + 'static,
+            I: serde::de::DeserializeOwned + Send + 'static,
+            O: serde::Serialize + Send + 'static,
+        {
+            self.stages.push(Box::new(TypedStageWrapper {
+                stage,
+                _phantom: std::marker::PhantomData,
+            }));
+            self
+        }
+
+        /// Build the pipeline, snapshotting the effective config.
+        pub fn build(self) -> Result<Pipeline> {
+            if self.stages.is_empty() {
+                return Err(GraphRAGError::Config {
+                    message: "Cannot build empty pipeline".to_string(),
+                });
+            }
+
+            let config_snapshot =
+                toml::to_string_pretty(&self.config).unwrap_or_else(|_| "{}".to_string());
+
+            Ok(Pipeline {
+                stages: self.stages,
+                config_snapshot,
+            })
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::config::Config;
+        use crate::pipeline::stage::{ChunkBatch, EmbeddingBatch};
+        use crate::core::{ChunkId, TextChunk, DocumentId};
+
+        /// Stage that converts a String into a ChunkBatch (single chunk).
+        struct StringToChunkStage;
+
+        #[async_trait]
+        impl Stage<String, ChunkBatch> for StringToChunkStage {
+            async fn process(&self, input: String) -> Result<ChunkBatch> {
+                let chunk = TextChunk {
+                    id: ChunkId::new("chunk_0".to_string()),
+                    document_id: DocumentId::new("doc_0".to_string()),
+                    content: input,
+                    start_offset: 0,
+                    end_offset: 0,
+                    embedding: None,
+                    entities: vec![],
+                    metadata: Default::default(),
+                };
+                Ok(ChunkBatch::new(vec![chunk]))
+            }
+            fn name(&self) -> &str {
+                "string_to_chunk"
+            }
+        }
+
+        /// Stage that converts ChunkBatch to EmbeddingBatch (fake embeddings).
+        struct ChunkToEmbeddingStage;
+
+        #[async_trait]
+        impl Stage<ChunkBatch, EmbeddingBatch> for ChunkToEmbeddingStage {
+            async fn process(&self, input: ChunkBatch) -> Result<EmbeddingBatch> {
+                let embeddings = input
+                    .0
+                    .iter()
+                    .map(|c| (c.id.clone(), vec![0.1_f32; 8]))
+                    .collect();
+                Ok(EmbeddingBatch::new(embeddings))
+            }
+            fn name(&self) -> &str {
+                "chunk_to_embedding"
+            }
+        }
+
+        #[tokio::test]
+        async fn test_two_stage_pipeline() {
+            let config = Config::default();
+            let pipeline = PipelineBuilder::new(config)
+                .add_stage(StringToChunkStage)
+                .add_stage(ChunkToEmbeddingStage)
+                .build()
+                .unwrap();
+
+            assert_eq!(pipeline.stage_count(), 2);
+            assert_eq!(
+                pipeline.stage_names(),
+                vec!["string_to_chunk", "chunk_to_embedding"]
+            );
+
+            let result: EmbeddingBatch = pipeline
+                .run("hello world".to_string())
+                .await
+                .unwrap();
+            assert_eq!(result.len(), 1);
+            assert_eq!(result.0[0].0, ChunkId::new("chunk_0".to_string()));
+        }
+
+        #[test]
+        fn test_config_snapshot() {
+            let config = Config::default();
+            let pipeline = PipelineBuilder::new(config)
+                .add_stage(StringToChunkStage)
+                .build()
+                .unwrap();
+
+            let snapshot = pipeline.effective_config();
+            assert!(!snapshot.is_empty());
+            // Should contain some config keys
+            assert!(snapshot.contains("chunk_size") || snapshot.contains("approach"));
+        }
+
+        #[test]
+        fn test_empty_pipeline_fails() {
+            let config = Config::default();
+            let result = PipelineBuilder::new(config).build();
+            assert!(result.is_err());
+        }
+    }
+}
+
+#[cfg(feature = "async")]
+pub use pipeline_builder::{Pipeline, PipelineBuilder};

--- a/graphrag-core/src/pipeline/mod.rs
+++ b/graphrag-core/src/pipeline/mod.rs
@@ -19,6 +19,10 @@
 //! - Data quality checks
 //! - Error handling and reporting
 
+/// Typed pipeline stage trait and batch contracts.
+#[cfg(feature = "async")]
+pub mod stage;
+
 // Data import requires async feature
 #[cfg(feature = "async")]
 pub mod data_import;
@@ -30,3 +34,6 @@ pub use data_import::{
     ImportedEntity, ImportedRelationship, ImportResult,
     ImportError, DataImporter, StreamingImporter, StreamingSource,
 };
+
+#[cfg(feature = "async")]
+pub use stage::{Stage, ChunkBatch, EmbeddingBatch, EntityGraphDelta, RetrievalSet};

--- a/graphrag-core/src/pipeline/stage.rs
+++ b/graphrag-core/src/pipeline/stage.rs
@@ -4,6 +4,7 @@
 
 use crate::core::{ChunkId, Result, TextChunk};
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
 #[cfg(feature = "incremental")]
@@ -33,7 +34,7 @@ pub trait Stage<I: Send + 'static, O: Send + 'static>: Send + Sync {
 // ============================================================================
 
 /// A batch of text chunks ready for embedding.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChunkBatch(pub Vec<TextChunk>);
 
 impl ChunkBatch {
@@ -54,7 +55,7 @@ impl ChunkBatch {
 }
 
 /// A batch of embeddings keyed by chunk ID.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddingBatch(pub Vec<(ChunkId, Vec<f32>)>);
 
 impl EmbeddingBatch {

--- a/graphrag-core/src/pipeline/stage.rs
+++ b/graphrag-core/src/pipeline/stage.rs
@@ -1,0 +1,201 @@
+//! Stage<I,O> trait and typed batch contracts for pipeline stages.
+//!
+//! Provides the core abstraction for composable, typed pipeline stages.
+
+use crate::core::{ChunkId, Result, TextChunk};
+use async_trait::async_trait;
+use std::fmt::Debug;
+
+#[cfg(feature = "incremental")]
+use crate::graph::incremental::GraphDelta;
+
+use crate::retrieval::SearchResult;
+
+// ============================================================================
+// Stage Trait
+// ============================================================================
+
+/// A typed, async pipeline stage transforming input `I` into output `O`.
+///
+/// Stages are the fundamental building blocks of processing pipelines.
+/// They can be composed sequentially via `PipelineBuilder`.
+#[async_trait]
+pub trait Stage<I: Send + 'static, O: Send + 'static>: Send + Sync {
+    /// Process the input and produce an output.
+    async fn process(&self, input: I) -> Result<O>;
+
+    /// Human-readable name of this stage (for logging/tracing).
+    fn name(&self) -> &str;
+}
+
+// ============================================================================
+// Typed Batch Newtypes
+// ============================================================================
+
+/// A batch of text chunks ready for embedding.
+#[derive(Debug, Clone)]
+pub struct ChunkBatch(pub Vec<TextChunk>);
+
+impl ChunkBatch {
+    /// Create a new chunk batch.
+    pub fn new(chunks: Vec<TextChunk>) -> Self {
+        Self(chunks)
+    }
+
+    /// Number of chunks in the batch.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the batch is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// A batch of embeddings keyed by chunk ID.
+#[derive(Debug, Clone)]
+pub struct EmbeddingBatch(pub Vec<(ChunkId, Vec<f32>)>);
+
+impl EmbeddingBatch {
+    /// Create a new embedding batch.
+    pub fn new(embeddings: Vec<(ChunkId, Vec<f32>)>) -> Self {
+        Self(embeddings)
+    }
+
+    /// Number of embeddings in the batch.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the batch is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// A graph delta produced by entity extraction, wrapping `GraphDelta`.
+#[derive(Debug, Clone)]
+pub struct EntityGraphDelta {
+    /// The underlying graph delta (available when `incremental` feature is enabled).
+    #[cfg(feature = "incremental")]
+    pub delta: GraphDelta,
+    /// Placeholder when `incremental` feature is disabled.
+    #[cfg(not(feature = "incremental"))]
+    _private: (),
+}
+
+impl EntityGraphDelta {
+    /// Create a new entity graph delta from a `GraphDelta`.
+    #[cfg(feature = "incremental")]
+    pub fn new(delta: GraphDelta) -> Self {
+        Self { delta }
+    }
+
+    /// Create an empty entity graph delta (non-incremental).
+    #[cfg(not(feature = "incremental"))]
+    pub fn empty() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// A set of retrieval results from a search stage.
+#[derive(Debug, Clone)]
+pub struct RetrievalSet(pub Vec<SearchResult>);
+
+impl RetrievalSet {
+    /// Create a new retrieval set.
+    pub fn new(results: Vec<SearchResult>) -> Self {
+        Self(results)
+    }
+
+    /// Number of results.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ChunkId;
+
+    /// A no-op stage that passes input through unchanged (compile test).
+    struct NoopStage;
+
+    #[async_trait]
+    impl Stage<String, String> for NoopStage {
+        async fn process(&self, input: String) -> Result<String> {
+            Ok(input)
+        }
+        fn name(&self) -> &str {
+            "noop"
+        }
+    }
+
+    #[tokio::test]
+    async fn test_noop_stage_compiles() {
+        let stage = NoopStage;
+        let result = stage.process("hello".to_string()).await.unwrap();
+        assert_eq!(result, "hello");
+        assert_eq!(stage.name(), "noop");
+    }
+
+    #[tokio::test]
+    async fn test_trait_object_creation() {
+        let stage: Box<dyn Stage<String, String>> = Box::new(NoopStage);
+        let result = stage.process("world".to_string()).await.unwrap();
+        assert_eq!(result, "world");
+    }
+
+    #[test]
+    fn test_chunk_batch_construction() {
+        let batch = ChunkBatch::new(vec![]);
+        assert!(batch.is_empty());
+        assert_eq!(batch.len(), 0);
+    }
+
+    #[test]
+    fn test_embedding_batch_construction() {
+        let batch = EmbeddingBatch::new(vec![
+            (ChunkId::new("c1".to_string()), vec![0.1, 0.2]),
+            (ChunkId::new("c2".to_string()), vec![0.3, 0.4]),
+        ]);
+        assert_eq!(batch.len(), 2);
+        assert!(!batch.is_empty());
+    }
+
+    #[test]
+    fn test_retrieval_set_construction() {
+        let set = RetrievalSet::new(vec![]);
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn test_entity_graph_delta_construction() {
+        #[cfg(feature = "incremental")]
+        {
+            use crate::graph::incremental::{DeltaStatus, GraphDelta, UpdateId};
+            let delta = GraphDelta {
+                delta_id: UpdateId::new(),
+                timestamp: chrono::Utc::now(),
+                changes: vec![],
+                dependencies: vec![],
+                status: DeltaStatus::Pending,
+                rollback_data: None,
+            };
+            let egd = EntityGraphDelta::new(delta);
+            assert!(egd.delta.changes.is_empty());
+        }
+
+        #[cfg(not(feature = "incremental"))]
+        {
+            let _egd = EntityGraphDelta::empty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- PipelineBuilder chaining Stage<I,O> objects via type-erased serde
- Pipeline::run and effective_config() support

Refs: issue #27 (Epic 1, Story 1.2)
Supersedes: #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)