### PR TITLE
feat: stage-level caching/memoization

### DIFF
--- a/graphrag-core/src/pipeline/cached_stage.rs
+++ b/graphrag-core/src/pipeline/cached_stage.rs
@@ -1,0 +1,215 @@
+//! Stage-level caching/memoization for pipeline stages.
+//!
+//! `CachedStage<I,O>` wraps any `Stage<I,O>` with content-hash caching
+//! using sha2 for cache keys and moka for in-memory TTL-based caching.
+
+use crate::core::Result;
+use crate::pipeline::stage::Stage;
+use async_trait::async_trait;
+use serde::{de::DeserializeOwned, Serialize};
+use sha2::{Digest, Sha256};
+use std::hash::Hash;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[cfg(feature = "caching")]
+use moka::future::Cache;
+
+/// A cached wrapper around any `Stage<I,O>`.
+///
+/// Caches stage outputs based on a content hash of the input.
+/// Requires `I: Serialize + Hash` and `O: Serialize + DeserializeOwned + Clone`.
+pub struct CachedStage<I, O>
+where
+    I: Send + 'static,
+    O: Send + 'static,
+{
+    inner: Arc<dyn Stage<I, O>>,
+    #[cfg(feature = "caching")]
+    cache: Cache<String, Vec<u8>>,
+    #[cfg(not(feature = "caching"))]
+    _phantom: std::marker::PhantomData<(I, O)>,
+    ttl: Duration,
+}
+
+impl<I, O> CachedStage<I, O>
+where
+    I: Serialize + Hash + Send + 'static,
+    O: Serialize + DeserializeOwned + Clone + Send + 'static,
+{
+    /// Create a new cached stage wrapping the given inner stage.
+    ///
+    /// `max_capacity` controls maximum number of cached entries.
+    /// `ttl` is the time-to-live for each cache entry.
+    pub fn new(inner: Arc<dyn Stage<I, O>>, max_capacity: u64, ttl: Duration) -> Self {
+        Self {
+            inner,
+            #[cfg(feature = "caching")]
+            cache: Cache::builder()
+                .max_capacity(max_capacity)
+                .time_to_live(ttl)
+                .build(),
+            #[cfg(not(feature = "caching"))]
+            _phantom: std::marker::PhantomData,
+            ttl,
+        }
+    }
+
+    /// Compute a cache key from the input using SHA-256.
+    fn cache_key(input: &I) -> String
+    where
+        I: Serialize,
+    {
+        let serialized = serde_json::to_vec(input).unwrap_or_default();
+        let hash = Sha256::digest(&serialized);
+        hex::encode(hash)
+    }
+
+    /// Get the configured TTL.
+    pub fn ttl(&self) -> Duration {
+        self.ttl
+    }
+}
+
+// hex encoding helper (avoiding a dependency)
+mod hex {
+    pub fn encode(bytes: impl AsRef<[u8]>) -> String {
+        bytes
+            .as_ref()
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect()
+    }
+}
+
+#[async_trait]
+impl<I, O> Stage<I, O> for CachedStage<I, O>
+where
+    I: Serialize + Hash + Send + Sync + 'static,
+    O: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
+{
+    async fn process(&self, input: I) -> Result<O> {
+        let key = Self::cache_key(&input);
+
+        // Check cache
+        #[cfg(feature = "caching")]
+        {
+            if let Some(cached_bytes) = self.cache.get(&key).await {
+                if let Ok(output) = serde_json::from_slice::<O>(&cached_bytes) {
+                    return Ok(output);
+                }
+            }
+        }
+
+        // Cache miss — run inner stage
+        let output = self.inner.process(input).await?;
+
+        // Store in cache
+        #[cfg(feature = "caching")]
+        {
+            if let Ok(bytes) = serde_json::to_vec(&output) {
+                self.cache.insert(key, bytes).await;
+            }
+        }
+
+        Ok(output)
+    }
+
+    fn name(&self) -> &str {
+        // Delegate to inner stage name with a prefix would lose the &str lifetime,
+        // so we just delegate directly.
+        self.inner.name()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::Result;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// A counting stage that tracks how many times process() is called.
+    struct CountingStage {
+        call_count: AtomicU64,
+    }
+
+    impl CountingStage {
+        fn new() -> Self {
+            Self {
+                call_count: AtomicU64::new(0),
+            }
+        }
+
+        fn calls(&self) -> u64 {
+            self.call_count.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl Stage<String, String> for CountingStage {
+        async fn process(&self, input: String) -> Result<String> {
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            Ok(format!("processed:{}", input))
+        }
+        fn name(&self) -> &str {
+            "counting"
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cache_miss() {
+        let inner = Arc::new(CountingStage::new());
+        let cached = CachedStage::new(
+            inner.clone(),
+            100,
+            Duration::from_secs(60),
+        );
+
+        let result = cached.process("hello".to_string()).await.unwrap();
+        assert_eq!(result, "processed:hello");
+        assert_eq!(inner.calls(), 1);
+    }
+
+    #[cfg(feature = "caching")]
+    #[tokio::test]
+    async fn test_cache_hit() {
+        let inner = Arc::new(CountingStage::new());
+        let cached = CachedStage::new(
+            inner.clone(),
+            100,
+            Duration::from_secs(60),
+        );
+
+        // First call — miss
+        let r1 = cached.process("hello".to_string()).await.unwrap();
+        assert_eq!(r1, "processed:hello");
+        assert_eq!(inner.calls(), 1);
+
+        // Second call — hit
+        let r2 = cached.process("hello".to_string()).await.unwrap();
+        assert_eq!(r2, "processed:hello");
+        assert_eq!(inner.calls(), 1); // inner not called again
+    }
+
+    #[cfg(feature = "caching")]
+    #[tokio::test]
+    async fn test_cache_ttl_expiry() {
+        let inner = Arc::new(CountingStage::new());
+        let cached = CachedStage::new(
+            inner.clone(),
+            100,
+            Duration::from_millis(50), // Very short TTL
+        );
+
+        cached.process("hello".to_string()).await.unwrap();
+        assert_eq!(inner.calls(), 1);
+
+        // Wait for TTL to expire
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // moka eviction may require a get after expiry
+        cached.process("hello".to_string()).await.unwrap();
+        // After TTL, inner should be called again
+        assert!(inner.calls() >= 2);
+    }
+}

--- a/graphrag-core/src/pipeline/mod.rs
+++ b/graphrag-core/src/pipeline/mod.rs
@@ -23,6 +23,10 @@
 #[cfg(feature = "async")]
 pub mod stage;
 
+/// Stage-level caching/memoization.
+#[cfg(feature = "async")]
+pub mod cached_stage;
+
 // Data import requires async feature
 #[cfg(feature = "async")]
 pub mod data_import;
@@ -37,3 +41,6 @@ pub use data_import::{
 
 #[cfg(feature = "async")]
 pub use stage::{Stage, ChunkBatch, EmbeddingBatch, EntityGraphDelta, RetrievalSet};
+
+#[cfg(feature = "async")]
+pub use cached_stage::CachedStage;

--- a/graphrag-core/src/pipeline/mod.rs
+++ b/graphrag-core/src/pipeline/mod.rs
@@ -19,6 +19,10 @@
 //! - Data quality checks
 //! - Error handling and reporting
 
+/// Typed pipeline stage trait and batch contracts.
+#[cfg(feature = "async")]
+pub mod stage;
+
 // Data import requires async feature
 #[cfg(feature = "async")]
 pub mod data_import;
@@ -30,3 +34,6 @@ pub use data_import::{
     ImportedEntity, ImportedRelationship, ImportResult,
     ImportError, DataImporter, StreamingImporter, StreamingSource,
 };
+
+#[cfg(feature = "async")]
+pub use stage::{Stage, ChunkBatch, EmbeddingBatch, EntityGraphDelta, RetrievalSet};

--- a/graphrag-core/src/pipeline/stage.rs
+++ b/graphrag-core/src/pipeline/stage.rs
@@ -1,0 +1,201 @@
+//! Stage<I,O> trait and typed batch contracts for pipeline stages.
+//!
+//! Provides the core abstraction for composable, typed pipeline stages.
+
+use crate::core::{ChunkId, Result, TextChunk};
+use async_trait::async_trait;
+use std::fmt::Debug;
+
+#[cfg(feature = "incremental")]
+use crate::graph::incremental::GraphDelta;
+
+use crate::retrieval::SearchResult;
+
+// ============================================================================
+// Stage Trait
+// ============================================================================
+
+/// A typed, async pipeline stage transforming input `I` into output `O`.
+///
+/// Stages are the fundamental building blocks of processing pipelines.
+/// They can be composed sequentially via `PipelineBuilder`.
+#[async_trait]
+pub trait Stage<I: Send + 'static, O: Send + 'static>: Send + Sync {
+    /// Process the input and produce an output.
+    async fn process(&self, input: I) -> Result<O>;
+
+    /// Human-readable name of this stage (for logging/tracing).
+    fn name(&self) -> &str;
+}
+
+// ============================================================================
+// Typed Batch Newtypes
+// ============================================================================
+
+/// A batch of text chunks ready for embedding.
+#[derive(Debug, Clone)]
+pub struct ChunkBatch(pub Vec<TextChunk>);
+
+impl ChunkBatch {
+    /// Create a new chunk batch.
+    pub fn new(chunks: Vec<TextChunk>) -> Self {
+        Self(chunks)
+    }
+
+    /// Number of chunks in the batch.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the batch is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// A batch of embeddings keyed by chunk ID.
+#[derive(Debug, Clone)]
+pub struct EmbeddingBatch(pub Vec<(ChunkId, Vec<f32>)>);
+
+impl EmbeddingBatch {
+    /// Create a new embedding batch.
+    pub fn new(embeddings: Vec<(ChunkId, Vec<f32>)>) -> Self {
+        Self(embeddings)
+    }
+
+    /// Number of embeddings in the batch.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the batch is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// A graph delta produced by entity extraction, wrapping `GraphDelta`.
+#[derive(Debug, Clone)]
+pub struct EntityGraphDelta {
+    /// The underlying graph delta (available when `incremental` feature is enabled).
+    #[cfg(feature = "incremental")]
+    pub delta: GraphDelta,
+    /// Placeholder when `incremental` feature is disabled.
+    #[cfg(not(feature = "incremental"))]
+    _private: (),
+}
+
+impl EntityGraphDelta {
+    /// Create a new entity graph delta from a `GraphDelta`.
+    #[cfg(feature = "incremental")]
+    pub fn new(delta: GraphDelta) -> Self {
+        Self { delta }
+    }
+
+    /// Create an empty entity graph delta (non-incremental).
+    #[cfg(not(feature = "incremental"))]
+    pub fn empty() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// A set of retrieval results from a search stage.
+#[derive(Debug, Clone)]
+pub struct RetrievalSet(pub Vec<SearchResult>);
+
+impl RetrievalSet {
+    /// Create a new retrieval set.
+    pub fn new(results: Vec<SearchResult>) -> Self {
+        Self(results)
+    }
+
+    /// Number of results.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ChunkId;
+
+    /// A no-op stage that passes input through unchanged (compile test).
+    struct NoopStage;
+
+    #[async_trait]
+    impl Stage<String, String> for NoopStage {
+        async fn process(&self, input: String) -> Result<String> {
+            Ok(input)
+        }
+        fn name(&self) -> &str {
+            "noop"
+        }
+    }
+
+    #[tokio::test]
+    async fn test_noop_stage_compiles() {
+        let stage = NoopStage;
+        let result = stage.process("hello".to_string()).await.unwrap();
+        assert_eq!(result, "hello");
+        assert_eq!(stage.name(), "noop");
+    }
+
+    #[tokio::test]
+    async fn test_trait_object_creation() {
+        let stage: Box<dyn Stage<String, String>> = Box::new(NoopStage);
+        let result = stage.process("world".to_string()).await.unwrap();
+        assert_eq!(result, "world");
+    }
+
+    #[test]
+    fn test_chunk_batch_construction() {
+        let batch = ChunkBatch::new(vec![]);
+        assert!(batch.is_empty());
+        assert_eq!(batch.len(), 0);
+    }
+
+    #[test]
+    fn test_embedding_batch_construction() {
+        let batch = EmbeddingBatch::new(vec![
+            (ChunkId::new("c1".to_string()), vec![0.1, 0.2]),
+            (ChunkId::new("c2".to_string()), vec![0.3, 0.4]),
+        ]);
+        assert_eq!(batch.len(), 2);
+        assert!(!batch.is_empty());
+    }
+
+    #[test]
+    fn test_retrieval_set_construction() {
+        let set = RetrievalSet::new(vec![]);
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn test_entity_graph_delta_construction() {
+        #[cfg(feature = "incremental")]
+        {
+            use crate::graph::incremental::{DeltaStatus, GraphDelta, UpdateId};
+            let delta = GraphDelta {
+                delta_id: UpdateId::new(),
+                timestamp: chrono::Utc::now(),
+                changes: vec![],
+                dependencies: vec![],
+                status: DeltaStatus::Pending,
+                rollback_data: None,
+            };
+            let egd = EntityGraphDelta::new(delta);
+            assert!(egd.delta.changes.is_empty());
+        }
+
+        #[cfg(not(feature = "incremental"))]
+        {
+            let _egd = EntityGraphDelta::empty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- CachedStage<I,O> wrapping any Stage<I,O>
- sha2 content-hash keys, moka future::Cache for TTL-based caching

Refs: issue #27 (Epic 1, Story 1.3)
Supersedes: #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)