### PR TITLE
feat(pipeline): CLI effective config + deterministic startup summary

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -87,9 +87,9 @@
             partitionType = "count";
           });
 
-          benches = craneLib.cargoCheck (commonArgs // {
+          benches = craneLib.cargoBuild (commonArgs // {
             inherit cargoArtifacts;
-            cargoCheckExtraArgs = "--workspace --benches";
+            cargoBuildExtraArgs = "--workspace --benches";
           });
 
           doc = craneLib.cargoDoc (commonArgs // {

--- a/graphrag-cli/Cargo.toml
+++ b/graphrag-cli/Cargo.toml
@@ -52,6 +52,7 @@ thiserror = "1.0"
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9"
 toml = "0.8"
 json5 = { version = "0.4", optional = true }
 


### PR DESCRIPTION
## Summary
- adds deterministic pipeline report rendering helpers in `graphrag-core::pipeline::builder`
- adds `graphrag-cli print-effective-config --config <FILE>` for TOML/YAML/JSON/JSON5 configs
- prints both effective config and startup stage rationale summary
- adds stability tests for rendered output to support Story 1.2 test gates

## Why
Implements an atomic slice from issue #27 roadmap (Story 1.2): config-driven pipeline visibility via `--print-effective-config` and startup summary output.

## Validation
- `cargo test -p graphrag-core pipeline::builder::tests::test_effective_config_report_contains_stages`
- `cargo test -p graphrag-core pipeline::builder::tests::test_startup_summary_is_stable_for_same_config`
- `cargo test -p graphrag-cli test_render_pipeline_reports_is_stable`

## Notes
- Full strict clippy currently fails in unrelated existing files (`graphrag-core/src/text/extractive_summarizer.rs`, `graphrag-core/src/summarization/mod.rs`) and was not modified in this PR.

Closes #36
Refs #27
