### PR TITLE
test(core): ollama coverage + nix CI/cache fixes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,8 @@
   # flake.nix and flake.lock files before merging.
 
   nixConfig = {
-    extra-substituters = [ "https://nix-cache.stevedores.org/stevedores" ];
-    extra-trusted-substituters = [ "https://nix-cache.stevedores.org/stevedores" ];
+    extra-substituters = [ "https://nix-cache.stevedores.org/" ];
+    extra-trusted-substituters = [ "https://nix-cache.stevedores.org/" ];
   };
 
   # NOTE: Inputs are pinned to exact commits via flake.lock (committed to repo).

--- a/flake.nix
+++ b/flake.nix
@@ -87,11 +87,6 @@
             partitionType = "count";
           });
 
-          benches = craneLib.cargoCheck (commonArgs // {
-            inherit cargoArtifacts;
-            cargoCheckExtraArgs = "--workspace --benches";
-          });
-
           doc = craneLib.cargoDoc (commonArgs // {
             inherit cargoArtifacts;
             cargoDocExtraArgs = "--workspace --no-deps";


### PR DESCRIPTION
## Summary
- add unit tests for OllamaConfig default values
- add test validating AsyncOllamaGenerator::model_info reflects configured model
- add feature-gated tests for completion error paths (ureq and non-ureq)
- fix Nix CI by removing unsupported crane cargoCheck benches check
- update Nix cache endpoint to https://nix-cache.stevedores.org/

## Validation
- cargo test -p graphrag-core ollama::tests -- --nocapture

---
_Migrated from stevedores-org/oxidizedRAG PR #57_