### PR TITLE
feat: CascadeFusion strategy for hybrid retrieval

### DIFF
--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -29,7 +29,7 @@ pub use fusion::{
     CascadeFusion, FusedResult, FusionMetrics, FusionPolicy, RankedResult, ReciprocalRankFusion,
     RetrievalSource, WeightedSum,
 };
-pub use hybrid::{FusionMethod, HybridConfig, HybridRetriever, HybridSearchResult};
+pub use hybrid::{CascadeConfig, FusionMethod, HybridConfig, HybridRetriever, HybridSearchResult};
 
 #[cfg(feature = "pagerank")]
 pub use pagerank_retrieval::{PageRankRetrievalSystem, ScoredResult};


### PR DESCRIPTION
## Summary
- Adds Cascade variant to FusionMethod enum
- CascadeConfig with score_threshold, cheap_k, expensive_k
- Runs BM25 first, escalates to vector if scores below threshold

Refs: issue #27 (Epic 2, Story 2.2)
Supersedes: #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Migrated from stevedores-org/oxidizedRAG PR #82_