### PR TITLE
feat: shared deployment contract types

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,44 @@
+name: Benchmark Regression Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'graphrag-core/**'
+      - 'benches/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bench-
+
+      - name: Run benchmarks
+        run: cargo bench --workspace -- --output-format bencher 2>/dev/null | tee bench-output.txt
+
+      - name: Check for regressions
+        run: bash scripts/bench-compare.sh bench-output.txt
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: bench-output.txt
+          retention-days: 90

--- a/graphrag-core/src/api/contracts.rs
+++ b/graphrag-core/src/api/contracts.rs
@@ -1,0 +1,274 @@
+//! Shared deployment contract types for server/CLI communication.
+//!
+//! These types define the wire format for GraphRAG API requests and responses,
+//! ensuring consistent serialization between server and client implementations.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Options controlling query behavior.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryOptions {
+    pub include_sources: bool,
+    pub include_scores: bool,
+    pub fusion_method: Option<String>,
+}
+
+/// A query request sent to the GraphRAG API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryRequest {
+    pub query: String,
+    pub limit: usize,
+    pub options: QueryOptions,
+}
+
+/// A single result item returned from a query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryResult {
+    pub id: String,
+    pub content: String,
+    pub score: f32,
+    pub source: Option<String>,
+}
+
+/// The response to a query request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryResponse {
+    pub results: Vec<QueryResult>,
+    pub total: usize,
+    pub query_time_ms: u64,
+}
+
+/// A single document to be indexed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexDocument {
+    pub id: String,
+    pub content: String,
+    pub metadata: HashMap<String, String>,
+}
+
+/// A request to index one or more documents.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexRequest {
+    pub documents: Vec<IndexDocument>,
+}
+
+/// The response after an indexing operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexResponse {
+    pub indexed: usize,
+    pub errors: Vec<String>,
+}
+
+/// Health check response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthResponse {
+    pub status: String,
+    pub version: String,
+    pub uptime_seconds: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: serialize to JSON and deserialize back, asserting round-trip equality.
+    fn roundtrip<T>(value: &T) -> T
+    where
+        T: Serialize + for<'de> Deserialize<'de> + std::fmt::Debug,
+    {
+        let json = serde_json::to_string(value).expect("serialize");
+        serde_json::from_str(&json).expect("deserialize")
+    }
+
+    #[test]
+    fn test_query_options_roundtrip() {
+        let opts = QueryOptions {
+            include_sources: true,
+            include_scores: false,
+            fusion_method: Some("rrf".to_string()),
+        };
+        let rt = roundtrip(&opts);
+        assert_eq!(rt.include_sources, opts.include_sources);
+        assert_eq!(rt.include_scores, opts.include_scores);
+        assert_eq!(rt.fusion_method, opts.fusion_method);
+    }
+
+    #[test]
+    fn test_query_options_none_fusion() {
+        let opts = QueryOptions {
+            include_sources: false,
+            include_scores: true,
+            fusion_method: None,
+        };
+        let rt = roundtrip(&opts);
+        assert!(rt.fusion_method.is_none());
+    }
+
+    #[test]
+    fn test_query_request_roundtrip() {
+        let req = QueryRequest {
+            query: "What is GraphRAG?".to_string(),
+            limit: 10,
+            options: QueryOptions {
+                include_sources: true,
+                include_scores: true,
+                fusion_method: None,
+            },
+        };
+        let rt = roundtrip(&req);
+        assert_eq!(rt.query, req.query);
+        assert_eq!(rt.limit, req.limit);
+        assert_eq!(rt.options.include_sources, true);
+    }
+
+    #[test]
+    fn test_query_result_roundtrip() {
+        let result = QueryResult {
+            id: "doc-1".to_string(),
+            content: "GraphRAG combines graphs with RAG.".to_string(),
+            score: 0.95,
+            source: Some("paper.pdf".to_string()),
+        };
+        let rt = roundtrip(&result);
+        assert_eq!(rt.id, result.id);
+        assert_eq!(rt.content, result.content);
+        assert_eq!(rt.score, result.score);
+        assert_eq!(rt.source, result.source);
+    }
+
+    #[test]
+    fn test_query_result_no_source() {
+        let result = QueryResult {
+            id: "doc-2".to_string(),
+            content: "Some content".to_string(),
+            score: 0.5,
+            source: None,
+        };
+        let rt = roundtrip(&result);
+        assert!(rt.source.is_none());
+    }
+
+    #[test]
+    fn test_query_response_roundtrip() {
+        let resp = QueryResponse {
+            results: vec![
+                QueryResult {
+                    id: "1".to_string(),
+                    content: "First".to_string(),
+                    score: 0.9,
+                    source: None,
+                },
+                QueryResult {
+                    id: "2".to_string(),
+                    content: "Second".to_string(),
+                    score: 0.8,
+                    source: Some("src.txt".to_string()),
+                },
+            ],
+            total: 2,
+            query_time_ms: 42,
+        };
+        let rt = roundtrip(&resp);
+        assert_eq!(rt.results.len(), 2);
+        assert_eq!(rt.total, resp.total);
+        assert_eq!(rt.query_time_ms, resp.query_time_ms);
+    }
+
+    #[test]
+    fn test_query_response_empty() {
+        let resp = QueryResponse {
+            results: vec![],
+            total: 0,
+            query_time_ms: 1,
+        };
+        let rt = roundtrip(&resp);
+        assert!(rt.results.is_empty());
+    }
+
+    #[test]
+    fn test_index_document_roundtrip() {
+        let mut metadata = HashMap::new();
+        metadata.insert("author".to_string(), "Alice".to_string());
+        metadata.insert("year".to_string(), "2025".to_string());
+
+        let doc = IndexDocument {
+            id: "doc-42".to_string(),
+            content: "Document content here.".to_string(),
+            metadata,
+        };
+        let rt = roundtrip(&doc);
+        assert_eq!(rt.id, doc.id);
+        assert_eq!(rt.content, doc.content);
+        assert_eq!(rt.metadata.get("author").unwrap(), "Alice");
+        assert_eq!(rt.metadata.get("year").unwrap(), "2025");
+    }
+
+    #[test]
+    fn test_index_document_empty_metadata() {
+        let doc = IndexDocument {
+            id: "doc-0".to_string(),
+            content: "No metadata".to_string(),
+            metadata: HashMap::new(),
+        };
+        let rt = roundtrip(&doc);
+        assert!(rt.metadata.is_empty());
+    }
+
+    #[test]
+    fn test_index_request_roundtrip() {
+        let req = IndexRequest {
+            documents: vec![
+                IndexDocument {
+                    id: "a".to_string(),
+                    content: "Alpha".to_string(),
+                    metadata: HashMap::new(),
+                },
+                IndexDocument {
+                    id: "b".to_string(),
+                    content: "Beta".to_string(),
+                    metadata: HashMap::new(),
+                },
+            ],
+        };
+        let rt = roundtrip(&req);
+        assert_eq!(rt.documents.len(), 2);
+        assert_eq!(rt.documents[0].id, "a");
+        assert_eq!(rt.documents[1].id, "b");
+    }
+
+    #[test]
+    fn test_index_response_roundtrip() {
+        let resp = IndexResponse {
+            indexed: 5,
+            errors: vec!["failed doc-3".to_string()],
+        };
+        let rt = roundtrip(&resp);
+        assert_eq!(rt.indexed, resp.indexed);
+        assert_eq!(rt.errors, resp.errors);
+    }
+
+    #[test]
+    fn test_index_response_no_errors() {
+        let resp = IndexResponse {
+            indexed: 10,
+            errors: vec![],
+        };
+        let rt = roundtrip(&resp);
+        assert_eq!(rt.indexed, 10);
+        assert!(rt.errors.is_empty());
+    }
+
+    #[test]
+    fn test_health_response_roundtrip() {
+        let resp = HealthResponse {
+            status: "healthy".to_string(),
+            version: "0.1.0".to_string(),
+            uptime_seconds: 3600,
+        };
+        let rt = roundtrip(&resp);
+        assert_eq!(rt.status, resp.status);
+        assert_eq!(rt.version, resp.version);
+        assert_eq!(rt.uptime_seconds, resp.uptime_seconds);
+    }
+}

--- a/graphrag-core/src/api/mod.rs
+++ b/graphrag-core/src/api/mod.rs
@@ -7,6 +7,7 @@ pub mod simple;
 pub mod easy;
 pub mod rest;
 pub mod handlers;
+pub mod contracts;
 
 #[cfg(test)]
 mod tests;

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Benchmark regression checker.
+# Compares current benchmark output against a baseline (if present).
+# Fails if any benchmark regresses more than the threshold.
+set -euo pipefail
+
+THRESHOLD_PERCENT="${BENCH_REGRESSION_THRESHOLD:-15}"
+BENCH_FILE="${1:-bench-output.txt}"
+
+if [ ! -f "$BENCH_FILE" ]; then
+  echo "No benchmark file found at $BENCH_FILE"
+  exit 0
+fi
+
+echo "=== Benchmark Results ==="
+cat "$BENCH_FILE"
+echo ""
+
+# Check if we have a baseline to compare against
+BASELINE_FILE="bench-baseline.txt"
+if [ ! -f "$BASELINE_FILE" ]; then
+  echo "No baseline found at $BASELINE_FILE — skipping regression check."
+  echo "To set a baseline, run: cp $BENCH_FILE $BASELINE_FILE"
+  exit 0
+fi
+
+echo "=== Comparing against baseline ==="
+REGRESSION_FOUND=0
+
+while IFS= read -r line; do
+  # Parse bencher format: "test <name> ... bench: <ns> ns/iter (+/- <var>)"
+  if echo "$line" | grep -q "bench:"; then
+    NAME=$(echo "$line" | awk '{print $2}')
+    CURRENT_NS=$(echo "$line" | grep -oP 'bench:\s+\K[0-9,]+' | tr -d ',')
+
+    # Find matching baseline
+    BASELINE_NS=$(grep "$NAME" "$BASELINE_FILE" | grep -oP 'bench:\s+\K[0-9,]+' | tr -d ',' || true)
+
+    if [ -n "$BASELINE_NS" ] && [ "$BASELINE_NS" -gt 0 ] 2>/dev/null; then
+      CHANGE=$(( (CURRENT_NS - BASELINE_NS) * 100 / BASELINE_NS ))
+      if [ "$CHANGE" -gt "$THRESHOLD_PERCENT" ]; then
+        echo "REGRESSION: $NAME regressed by ${CHANGE}% (baseline: ${BASELINE_NS}ns, current: ${CURRENT_NS}ns)"
+        REGRESSION_FOUND=1
+      else
+        echo "OK: $NAME changed by ${CHANGE}%"
+      fi
+    fi
+  fi
+done < "$BENCH_FILE"
+
+if [ "$REGRESSION_FOUND" -eq 1 ]; then
+  echo ""
+  echo "FAILED: Benchmark regression(s) exceeded ${THRESHOLD_PERCENT}% threshold."
+  exit 1
+fi
+
+echo ""
+echo "PASSED: No benchmark regressions detected."
+exit 0


### PR DESCRIPTION
## Summary
- QueryRequest/Response, IndexRequest/Response, HealthResponse
- Serde-serializable shared contracts for server + CLI

Refs: issue #27 (Epic 6, Story 6.2)
Supersedes: #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Migrated from stevedores-org/oxidizedRAG PR #91_