### PR TITLE
fix: align local-ci config and docs with actual CLI schema

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Prefer local-ci if available (fast cached checks)
+# Prefer local-ci if available, while keeping strict clippy parity with fallback paths.
 if command -v local-ci >/dev/null 2>&1; then
-  echo "[pre-commit] running fmt + clippy via local-ci"
-  local-ci fmt clippy
+  echo "[pre-commit] running fmt via local-ci + strict clippy"
+  local-ci fmt
+  cargo clippy --workspace --all-targets -- -D warnings
 elif command -v nix >/dev/null 2>&1; then
   echo "[pre-commit] running rust fmt + clippy via nix develop"
   nix develop --command bash -c '

--- a/.local-ci.toml
+++ b/.local-ci.toml
@@ -1,6 +1,10 @@
 # local-ci configuration for oxidizedRAG
 # See: https://github.com/stevedores-org/local-ci
 #
+# NOTE: local-ci v0.1.0 uses built-in stage definitions and does not currently
+# parse this file. Keep this as forward-compatible documentation of desired
+# stage policy until schema-backed config loading lands in local-ci.
+#
 # Core stages run by default: fmt, clippy, test
 # Optional tool stages available below (requires installation):
 #   - deny: cargo-deny (security/license checking)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -43,16 +43,20 @@ To use unified CI pipeline in pre-commit hooks (optional):
 - Install:
   - `just local-ci-install`
 - Run full pipeline:
-  - `just local-ci` (or `local-ci run`)
-- Run individual stages:
-  - `just local-ci-lint` — fmt + clippy checks
-  - `just local-ci-security` — audit + deny checks
-  - `just local-ci-test` — unit tests + doc tests
+  - `just local-ci` (or `local-ci`)
+- Run fix mode:
+  - `just local-ci-fix` (or `local-ci --fix`)
+- Run selected stages:
+  - `local-ci fmt clippy`
+  - `local-ci test`
 - Benefits:
   - Unified configuration across all tools
-  - Parallel execution (when available)
+  - Fast cached stage runs
   - Consistent output formatting
   - Built-in caching strategy
+- Current limitation:
+  - `local-ci` currently uses built-in stage definitions (`fmt`, `clippy`, `test`, `check`)
+  - `.local-ci.toml` is forward-compatible policy documentation and not enforced yet by the binary
 
 ### Option B: Traditional direct commands
 
@@ -112,17 +116,8 @@ For self-hosted service environments, place `ATTIC_TOKEN` in an env file loaded 
 
 ## Local-CI Configuration
 
-The `.local-ci.toml` file defines a unified pipeline with the following stages:
-
-```toml
-[stages.lint]      # fmt + clippy checks
-[stages.security]  # cargo-audit + cargo-deny
-[stages.test]      # unit and doc tests
-[stages.bench]     # benchmark compilation
-[stages.doc]       # documentation build
-```
-
-Tools are cached by `Cargo.lock` hash for faster re-runs.
+`local-ci` currently executes built-in stages and does not load this file yet.
+Treat `.local-ci.toml` as desired policy documentation for upcoming schema-backed config support.
 
 ## Troubleshooting
 
@@ -133,7 +128,7 @@ Tools are cached by `Cargo.lock` hash for faster re-runs.
   - Add to PATH or ensure GOPATH/bin is in PATH
 - Stage fails to run:
   - Check configuration: `cat .local-ci.toml`
-  - Run with verbose output: `local-ci run --verbose`
+  - Run with verbose output: `local-ci --verbose fmt clippy test`
   - Verify tools are installed: `cargo audit --version`, `cargo deny --version`
 
 ### Pre-commit hook issues


### PR DESCRIPTION
## Summary

- Add forward-compatibility note to `.local-ci.toml` explaining v0.1.0 uses built-in stages
- Update `docs/ci.md` to use correct CLI syntax (`local-ci fmt clippy`, not `local-ci run --stage lint`)
- Remove stale references to `just local-ci-lint`, `just local-ci-security`, `just local-ci-test`
- Fix pre-commit hook to run `local-ci fmt` + explicit `cargo clippy` for strict parity

Ported from [oxidizedRAG PR #54](https://github.com/stevedores-org/oxidizedRAG/pull/54). The core config and justfile changes were already present; this brings the docs and pre-commit hook into alignment.

## Test plan

- [ ] `local-ci fmt` runs formatting check
- [ ] `local-ci --fix` auto-fixes formatting
- [ ] Pre-commit hook works with local-ci installed
- [ ] `just local-ci` runs full pipeline
- [ ] `just local-ci-fix` auto-fixes

Generated with Claude Code