### PR TITLE
chore: update repository URLs to stevedores-org/oxidizedRAG

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["GraphRAG-RS Contributors"]
 license = "MIT"
-repository = "https://github.com/yourusername/graphrag-rs"
+repository = "https://github.com/stevedores-org/oxidizedRAG"
 
 [workspace.dependencies]
 # Core dependencies (shared across crates)

--- a/config/schema/graphrag-config.schema.json
+++ b/config/schema/graphrag-config.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/yourusername/graphrag-rs/graphrag-config.schema.json",
+  "$id": "https://github.com/stevedores-org/oxidizedRAG/graphrag-config.schema.json",
   "title": "GraphRAG Configuration",
   "description": "GraphRAG configuration schema aligned with TOML structure",
   "type": "object",

--- a/graphrag-cli/GUIDA_ITALIANA.md
+++ b/graphrag-cli/GUIDA_ITALIANA.md
@@ -866,7 +866,7 @@ done > commands.txt
 ## 🤝 Contribuire
 
 Hai trovato bug o vuoi contribuire? Apri una issue o pull request su:
-https://github.com/yourusername/graphrag-rs
+https://github.com/stevedores-org/oxidizedRAG
 
 ---
 

--- a/graphrag-cli/README.md
+++ b/graphrag-cli/README.md
@@ -205,7 +205,7 @@ This TUI is inspired by modern terminal tools:
 
 ## 🤝 Contributing
 
-Contributions are welcome! This is part of the larger [graphrag-rs](https://github.com/yourusername/graphrag-rs) project.
+Contributions are welcome! This is part of the larger [graphrag-rs](https://github.com/stevedores-org/oxidizedRAG) project.
 
 ## 📄 License
 

--- a/graphrag-cli/USER_GUIDE.md
+++ b/graphrag-cli/USER_GUIDE.md
@@ -880,7 +880,7 @@ done > commands.txt
 ## 🤝 Contributing
 
 Found a bug or want to contribute? Open an issue or pull request at:
-https://github.com/yourusername/graphrag-rs
+https://github.com/stevedores-org/oxidizedRAG
 
 ---
 

--- a/graphrag-server/README.md
+++ b/graphrag-server/README.md
@@ -647,7 +647,7 @@ MIT
 - **Qdrant** - https://qdrant.tech/
 - **Actix-web** - https://actix.rs/
 - **Apistos** - https://github.com/netwo-io/apistos (OpenAPI 3.0.3 documentation)
-- **GraphRAG** - https://github.com/yourusername/graphrag-rs
+- **GraphRAG** - https://github.com/stevedores-org/oxidizedRAG
 
 ## Backend Comparison
 


### PR DESCRIPTION
## Summary
- Updated all `repository` URL references from `https://github.com/yourusername/graphrag-rs` to `https://github.com/stevedores-org/oxidizedRAG`
- Affected files: root `Cargo.toml`, JSON schema, CLI docs (USER_GUIDE.md, GUIDA_ITALIANA.md, README.md), and server README
- Workspace member crates inherit the repository field from the root Cargo.toml, so they are automatically updated

## Test plan
- [ ] Verify `cargo metadata` shows the correct repository URL
- [ ] Confirm no remaining references to `yourusername/graphrag-rs` in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)