### PR TITLE
fix(ci): align .local-ci.toml with local-ci CLI schema

### DIFF
--- a/.local-ci.toml
+++ b/.local-ci.toml
@@ -1,9 +1,9 @@
 # local-ci configuration for oxidizedRAG
 # See: https://github.com/stevedores-org/local-ci
 #
-# NOTE: local-ci v0.1.0 uses built-in stage definitions and does not currently
-# parse this file. Keep this as forward-compatible documentation of desired
-# stage policy until schema-backed config loading lands in local-ci.
+# Schema: use "command" and "fix_command" (not cmd/fixcmd). See PR #126.
+# Note: rustfmt.toml uses nightly-only options; for fmt to pass use
+#   cargo +nightly fmt --all   (or run CI via Nix: nix flake check).
 #
 # Core stages run by default: fmt, clippy, test
 # Optional tool stages available below (requires installation):
@@ -19,49 +19,49 @@ skip_dirs = [".git", "target", ".github", "scripts", ".claude", "node_modules", 
 include_patterns = ["*.rs", "*.toml"]
 
 [stages.fmt]
-cmd = ["cargo", "fmt", "--all", "--", "--check"]
-fixcmd = ["cargo", "fmt", "--all"]
+command = ["cargo", "fmt", "--all", "--", "--check"]
+fix_command = ["cargo", "fmt", "--all"]
 timeout = 120
 enabled = true
 
 [stages.clippy]
-cmd = ["cargo", "clippy", "--workspace", "--all-targets", "--", "-D", "warnings"]
+command = ["cargo", "clippy", "--workspace", "--all-targets", "--", "-D", "warnings"]
 timeout = 600
 enabled = true
 
 [stages.test]
-cmd = ["cargo", "test", "--workspace"]
+command = ["cargo", "test", "--workspace"]
 timeout = 1200
 enabled = true
 
 [stages.check]
-cmd = ["cargo", "check", "--workspace"]
+command = ["cargo", "check", "--workspace"]
 timeout = 600
 enabled = false
 
 # Optional: Cargo tools (uncomment to enable)
 # Install with: cargo install cargo-deny
 [stages.deny]
-cmd = ["cargo", "deny", "check"]
+command = ["cargo", "deny", "check"]
 timeout = 300
 enabled = false
 
 # Install with: cargo install cargo-audit
 [stages.audit]
-cmd = ["cargo", "audit"]
+command = ["cargo", "audit"]
 timeout = 300
 enabled = false
 
 # Install with: cargo install cargo-machete
 [stages.machete]
-cmd = ["cargo", "machete"]
+command = ["cargo", "machete"]
 timeout = 300
 enabled = false
 
 # Install with: cargo install taplo-cli
 [stages.taplo]
-cmd = ["taplo", "format", "--check", "."]
-fixcmd = ["taplo", "format", "."]
+command = ["taplo", "format", "--check", "."]
+fix_command = ["taplo", "format", "."]
 timeout = 300
 enabled = false
 

--- a/LOCAL_CI_AND_PR_CHECKS.md
+++ b/LOCAL_CI_AND_PR_CHECKS.md
@@ -1,0 +1,60 @@
+# local-ci and Fixing Failing PR Checks (oxidizedRAG)
+
+## What Was Done
+
+### 1. Fixed `.local-ci.toml` schema for local-ci
+
+The config used `cmd` / `fixcmd`, but [local-ci](https://github.com/stevedores-org/local-ci) expects **`command`** and **`fix_command`** in the TOML. That caused:
+
+```text
+stage "" has empty command
+```
+
+**Change:** All `[stages.*]` entries were updated to use `command` and `fix_command` instead of `cmd` and `fixcmd`. This matches the schema and PR #126 (“align local-ci config and docs with actual CLI schema”).
+
+### 2. Running local-ci
+
+After the config fix, running:
+
+```bash
+cd /path/to/oxidizedRAG
+/path/to/local-ci/local-ci --no-cache
+```
+
+- **fmt** fails because `rustfmt.toml` uses **nightly-only options** (e.g. `imports_granularity`, `wrap_comments`). Stable `cargo fmt` ignores them and reports many formatting diffs. PR #127 fixes this in **Nix CI** by using nightly rustfmt there; locally you can run `cargo +nightly fmt --all` before local-ci, or rely on Nix.
+- **clippy** (and then **test**) hit a **compile error** in `graphrag-core`:
+
+  ```text
+  error[E0599]: no method named `process` found for struct `Arc<(dyn Stage<I, O> + 'static)>`
+     --> graphrag-core/src/pipeline/cached_stage.rs:105
+  ```
+
+  So the current `main` (or the branch you’re on) has a Rust API/trait issue that must be fixed before clippy/test can pass.
+
+## How to Use local-ci to Help With PRs
+
+1. **Clone and use the fixed config**  
+   Ensure `.local-ci.toml` uses `command` / `fix_command` (as in this fix). Then local-ci will at least parse and run the pipeline instead of failing with “empty command”.
+
+2. **Format (fmt)**  
+   - **Option A:** Use nightly: `cargo +nightly fmt --all` then `local-ci` (or set `command = ["cargo", "+nightly", "fmt", ...]` in `.local-ci.toml` if everyone has nightly).  
+   - **Option B:** Use Nix: `nix develop --command cargo fmt --all` and rely on CI (e.g. PR #127) for the canonical fmt check.
+
+3. **Build / clippy / test**  
+   Fix the `graphrag-core` compile error (trait in scope or `dyn Stage` API) so that `cargo clippy` and `cargo test` succeed. Then local-ci’s clippy and test stages will pass.
+
+4. **CI on GitHub**  
+   oxidizedRAG CI is Nix-based (`.github/workflows/ci.yml`: `nix flake check`, `nix develop --command cargo test`, etc.). So:
+   - **Nix check** is the source of truth for “will this PR pass CI?”.
+   - **local-ci** is a fast, local mirror of the **cargo** parts (fmt, clippy, test) once the config is fixed and the code compiles.
+
+## Open PRs and Checks
+
+- **#129** – docs: CLAUDE.md (1 task; mergeable: unstable).  
+- **#128** – ci: Attic cache (2 tasks; self-review notes on derivation vs output paths, etc.).  
+- **#127** – fix: nightly rustfmt in Nix CI (2 tasks; mergeable: dirty; addresses fmt failures).  
+- **#126** – fix: align local-ci config with CLI schema (same schema fix as above).  
+- **#124** – docs: AI agent instruction files (2 tasks).  
+- **#122** – feat: content-addressed stage-level caching (3 tasks).
+
+Using local-ci (with the fixed `.local-ci.toml`) helps catch fmt/clippy/test issues before pushing; for the full CI story (including Nix and nightly rustfmt), rely on `nix flake check` and the workflows.


### PR DESCRIPTION
## Summary
Fixes local-ci failing with `stage "" has empty command` when running in oxidizedRAG.

## Changes
- **.local-ci.toml:** Use `command` and `fix_command` (instead of `cmd` / `fixcmd`) so the config matches the [local-ci](https://github.com/stevedores-org/local-ci) CLI schema. Same alignment as discussed in PR #126.
- **Comment:** Note that rustfmt.toml uses nightly-only options; for fmt to pass use `cargo +nightly fmt` or Nix.
- **LOCAL_CI_AND_PR_CHECKS.md:** Runbook for running local-ci and understanding failing PR checks (fmt nightly, Nix CI, graphrag-core compile).

## Testing
`local-ci --no-cache` in repo root now runs the pipeline (fmt/clippy/test); fmt still fails without nightly rustfmt; clippy/test fail on existing graphrag-core compile error until that is fixed.

Made with [Cursor](https://cursor.com)