### PR TITLE
feat: add llm-d manifest integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7248,6 +7248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "llm-d-validation"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_yaml",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "local-channel"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ members = [
     "graphrag-server",
     "graphrag-cli",
     "graphrag-aivcs",
+
+    # Tools
+    "tools/llm-d-validation",
 ]
 exclude = ["examples/web-app"]
 resolver = "2"

--- a/tools/llm-d-validation/Cargo.toml
+++ b/tools/llm-d-validation/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "llm-d-validation"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+name = "llm_d_validation"
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_yaml.workspace = true
+thiserror.workspace = true

--- a/tools/llm-d-validation/base/epp-deployment.yaml
+++ b/tools/llm-d-validation/base/epp-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-pool-epp
+  namespace: llm-d-inference
+  labels:
+    app: llm-pool-epp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llm-pool-epp
+  template:
+    metadata:
+      labels:
+        app: llm-pool-epp
+    spec:
+      containers:
+        - name: epp
+          image: registry.k8s.io/gateway-api/epp:v0.3.0
+          env:
+            - name: POOL_NAME
+              value: llm-pool
+            - name: POOL_NAMESPACE
+              value: llm-d-inference
+          ports:
+            - containerPort: 9002
+              name: grpc
+          readinessProbe:
+            grpc:
+              port: 9002
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/tools/llm-d-validation/base/httproute.yaml
+++ b/tools/llm-d-validation/base/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: llm-route
+  namespace: llm-d-inference
+spec:
+  parentRefs:
+    - name: llm-gateway
+      namespace: llm-d-inference
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: llm-pool
+          group: inference.networking.x-k8s.io
+          kind: InferencePool
+          port: 8000

--- a/tools/llm-d-validation/base/inferencemodel.yaml
+++ b/tools/llm-d-validation/base/inferencemodel.yaml
@@ -1,0 +1,10 @@
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferenceModel
+metadata:
+  name: deepseek-r1
+  namespace: llm-d-inference
+spec:
+  modelName: deepseek-r1
+  criticality: Critical
+  poolRef:
+    name: llm-pool

--- a/tools/llm-d-validation/base/inferencepool.yaml
+++ b/tools/llm-d-validation/base/inferencepool.yaml
@@ -1,0 +1,13 @@
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferencePool
+metadata:
+  name: llm-pool
+  namespace: llm-d-inference
+spec:
+  targetPortNumber: 8000
+  selector:
+    app: vllm
+  extensionRef:
+    name: llm-pool-epp
+    group: ""
+    kind: Service

--- a/tools/llm-d-validation/src/lib.rs
+++ b/tools/llm-d-validation/src/lib.rs
@@ -1,0 +1,269 @@
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ValidationError {
+    #[error("failed to read file: {0}")]
+    FileRead(#[from] std::io::Error),
+
+    #[error("failed to parse YAML: {0}")]
+    YamlParse(#[from] serde_yaml::Error),
+
+    #[error("invalid manifest: {0}")]
+    Invalid(String),
+}
+
+pub type Result<T> = std::result::Result<T, ValidationError>;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct K8sDocument {
+    pub api_version: String,
+    pub kind: String,
+    pub metadata: Metadata,
+    #[serde(default)]
+    pub spec: serde_yaml::Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Metadata {
+    pub name: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
+    #[serde(default)]
+    pub labels: Option<serde_yaml::Value>,
+}
+
+/// Load and parse a YAML manifest from an arbitrary path.
+pub fn load_manifest(path: &Path) -> Result<K8sDocument> {
+    let content = std::fs::read_to_string(path)?;
+    let doc: K8sDocument = serde_yaml::from_str(&content)?;
+    Ok(doc)
+}
+
+/// Load a manifest relative to the crate root (using `CARGO_MANIFEST_DIR`).
+pub fn validate_manifest_file(relative_path: &str) -> Result<K8sDocument> {
+    let base = env!("CARGO_MANIFEST_DIR");
+    let path = Path::new(base).join(relative_path);
+    load_manifest(&path)
+}
+
+pub fn validate_inference_pool(doc: &K8sDocument) -> Result<()> {
+    if doc.kind != "InferencePool" {
+        return Err(ValidationError::Invalid(format!(
+            "expected kind InferencePool, got {}",
+            doc.kind
+        )));
+    }
+    if !doc
+        .api_version
+        .starts_with("inference.networking.x-k8s.io/")
+    {
+        return Err(ValidationError::Invalid(format!(
+            "unexpected apiVersion: {}",
+            doc.api_version
+        )));
+    }
+
+    let spec = &doc.spec;
+    if spec.get("targetPortNumber").is_none() {
+        return Err(ValidationError::Invalid(
+            "spec.targetPortNumber is required".into(),
+        ));
+    }
+    if spec.get("selector").is_none() {
+        return Err(ValidationError::Invalid("spec.selector is required".into()));
+    }
+    if spec.get("extensionRef").is_none() {
+        return Err(ValidationError::Invalid(
+            "spec.extensionRef is required".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn validate_inference_model(doc: &K8sDocument, expected_pool: Option<&str>) -> Result<()> {
+    if doc.kind != "InferenceModel" {
+        return Err(ValidationError::Invalid(format!(
+            "expected kind InferenceModel, got {}",
+            doc.kind
+        )));
+    }
+    if !doc
+        .api_version
+        .starts_with("inference.networking.x-k8s.io/")
+    {
+        return Err(ValidationError::Invalid(format!(
+            "unexpected apiVersion: {}",
+            doc.api_version
+        )));
+    }
+
+    let spec = &doc.spec;
+    if spec.get("modelName").is_none() {
+        return Err(ValidationError::Invalid(
+            "spec.modelName is required".into(),
+        ));
+    }
+    if spec.get("criticality").is_none() {
+        return Err(ValidationError::Invalid(
+            "spec.criticality is required".into(),
+        ));
+    }
+
+    let pool_ref = spec
+        .get("poolRef")
+        .ok_or_else(|| ValidationError::Invalid("spec.poolRef is required".into()))?;
+    let pool_name = pool_ref
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ValidationError::Invalid("spec.poolRef.name is required".into()))?;
+
+    if let Some(expected) = expected_pool {
+        if pool_name != expected {
+            return Err(ValidationError::Invalid(format!(
+                "poolRef.name mismatch: expected {expected}, got {pool_name}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_epp_deployment(doc: &K8sDocument) -> Result<()> {
+    if doc.kind != "Deployment" {
+        return Err(ValidationError::Invalid(format!(
+            "expected kind Deployment, got {}",
+            doc.kind
+        )));
+    }
+
+    let spec = &doc.spec;
+    let template = spec
+        .get("template")
+        .ok_or_else(|| ValidationError::Invalid("spec.template is required".into()))?;
+    let containers = template
+        .get("spec")
+        .and_then(|s| s.get("containers"))
+        .and_then(|c| c.as_sequence())
+        .ok_or_else(|| {
+            ValidationError::Invalid("spec.template.spec.containers is required".into())
+        })?;
+
+    if containers.is_empty() {
+        return Err(ValidationError::Invalid(
+            "at least one container is required".into(),
+        ));
+    }
+
+    let container = &containers[0];
+
+    // Check required env vars
+    let env_vars = container
+        .get("env")
+        .and_then(|e| e.as_sequence())
+        .ok_or_else(|| ValidationError::Invalid("container env vars are required".into()))?;
+
+    let env_names: Vec<&str> = env_vars
+        .iter()
+        .filter_map(|e| e.get("name").and_then(|n| n.as_str()))
+        .collect();
+
+    for required in &["POOL_NAME", "POOL_NAMESPACE"] {
+        if !env_names.contains(required) {
+            return Err(ValidationError::Invalid(format!(
+                "missing required env var: {required}"
+            )));
+        }
+    }
+
+    // Check readiness probe
+    if container.get("readinessProbe").is_none() {
+        return Err(ValidationError::Invalid(
+            "container readinessProbe is required".into(),
+        ));
+    }
+
+    // Check resources
+    if container.get("resources").is_none() {
+        return Err(ValidationError::Invalid(
+            "container resources are required".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn validate_httproute(doc: &K8sDocument) -> Result<()> {
+    if doc.kind != "HTTPRoute" {
+        return Err(ValidationError::Invalid(format!(
+            "expected kind HTTPRoute, got {}",
+            doc.kind
+        )));
+    }
+    if !doc.api_version.starts_with("gateway.networking.k8s.io/") {
+        return Err(ValidationError::Invalid(format!(
+            "unexpected apiVersion: {}",
+            doc.api_version
+        )));
+    }
+
+    let spec = &doc.spec;
+    let parent_refs = spec
+        .get("parentRefs")
+        .and_then(|p| p.as_sequence())
+        .ok_or_else(|| ValidationError::Invalid("spec.parentRefs is required".into()))?;
+
+    if parent_refs.is_empty() {
+        return Err(ValidationError::Invalid(
+            "spec.parentRefs must not be empty".into(),
+        ));
+    }
+
+    let rules = spec
+        .get("rules")
+        .and_then(|r| r.as_sequence())
+        .ok_or_else(|| ValidationError::Invalid("spec.rules is required".into()))?;
+
+    // Check that at least one rule has backendRefs
+    let has_backend_refs = rules.iter().any(|rule| {
+        rule.get("backendRefs")
+            .and_then(|b| b.as_sequence())
+            .map(|b| !b.is_empty())
+            .unwrap_or(false)
+    });
+
+    if !has_backend_refs {
+        return Err(ValidationError::Invalid(
+            "at least one rule must have backendRefs".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Run all four validations and collect errors.
+pub fn validate_all(
+    pool: &K8sDocument,
+    model: &K8sDocument,
+    epp: &K8sDocument,
+    route: &K8sDocument,
+) -> Vec<ValidationError> {
+    let mut errors = Vec::new();
+
+    if let Err(e) = validate_inference_pool(pool) {
+        errors.push(e);
+    }
+    if let Err(e) = validate_inference_model(model, Some(&pool.metadata.name)) {
+        errors.push(e);
+    }
+    if let Err(e) = validate_epp_deployment(epp) {
+        errors.push(e);
+    }
+    if let Err(e) = validate_httproute(route) {
+        errors.push(e);
+    }
+
+    errors
+}

--- a/tools/llm-d-validation/tests/manifest_integration.rs
+++ b/tools/llm-d-validation/tests/manifest_integration.rs
@@ -1,0 +1,95 @@
+use llm_d_validation::{
+    validate_all, validate_epp_deployment, validate_httproute, validate_inference_model,
+    validate_inference_pool, validate_manifest_file,
+};
+
+#[test]
+fn test_actual_inferencepool_manifest_valid() {
+    let doc = validate_manifest_file("base/inferencepool.yaml").unwrap();
+    validate_inference_pool(&doc).unwrap();
+}
+
+#[test]
+fn test_actual_inferencemodel_manifest_valid() {
+    let pool = validate_manifest_file("base/inferencepool.yaml").unwrap();
+    let model = validate_manifest_file("base/inferencemodel.yaml").unwrap();
+    validate_inference_model(&model, Some(&pool.metadata.name)).unwrap();
+}
+
+#[test]
+fn test_actual_epp_deployment_manifest_valid() {
+    let doc = validate_manifest_file("base/epp-deployment.yaml").unwrap();
+    validate_epp_deployment(&doc).unwrap();
+}
+
+#[test]
+fn test_actual_httproute_manifest_valid() {
+    let doc = validate_manifest_file("base/httproute.yaml").unwrap();
+    validate_httproute(&doc).unwrap();
+}
+
+#[test]
+fn test_actual_full_stack_validates() {
+    let pool = validate_manifest_file("base/inferencepool.yaml").unwrap();
+    let model = validate_manifest_file("base/inferencemodel.yaml").unwrap();
+    let epp = validate_manifest_file("base/epp-deployment.yaml").unwrap();
+    let route = validate_manifest_file("base/httproute.yaml").unwrap();
+
+    let errors = validate_all(&pool, &model, &epp, &route);
+    assert!(errors.is_empty(), "validation errors: {errors:?}");
+}
+
+#[test]
+fn test_actual_manifests_cross_reference_consistency() {
+    let pool = validate_manifest_file("base/inferencepool.yaml").unwrap();
+    let model = validate_manifest_file("base/inferencemodel.yaml").unwrap();
+    let epp = validate_manifest_file("base/epp-deployment.yaml").unwrap();
+    let route = validate_manifest_file("base/httproute.yaml").unwrap();
+
+    let pool_name = &pool.metadata.name;
+    assert_eq!(pool_name, "llm-pool");
+
+    // Model's poolRef.name must match pool name
+    let model_pool_ref = model
+        .spec
+        .get("poolRef")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .expect("model should have poolRef.name");
+    assert_eq!(model_pool_ref, pool_name);
+
+    // EPP's POOL_NAME env var must match pool name
+    let containers = epp
+        .spec
+        .get("template")
+        .and_then(|t| t.get("spec"))
+        .and_then(|s| s.get("containers"))
+        .and_then(|c| c.as_sequence())
+        .expect("epp should have containers");
+    let env_vars = containers[0]
+        .get("env")
+        .and_then(|e| e.as_sequence())
+        .expect("epp container should have env");
+    let pool_name_env = env_vars
+        .iter()
+        .find(|e| e.get("name").and_then(|n| n.as_str()) == Some("POOL_NAME"))
+        .and_then(|e| e.get("value"))
+        .and_then(|v| v.as_str())
+        .expect("POOL_NAME env var should exist");
+    assert_eq!(pool_name_env, pool_name);
+
+    // HTTPRoute's backendRef name must match pool name
+    let rules = route
+        .spec
+        .get("rules")
+        .and_then(|r| r.as_sequence())
+        .expect("route should have rules");
+    let backend_ref_name = rules[0]
+        .get("backendRefs")
+        .and_then(|b| b.as_sequence())
+        .and_then(|b| b.first())
+        .and_then(|r| r.get("name"))
+        .and_then(|n| n.as_str())
+        .expect("route should have backendRef name");
+    assert_eq!(backend_ref_name, pool_name);
+}


### PR DESCRIPTION
## Summary

- Adds `tools/llm-d-validation` crate with Kubernetes manifest validation for llm-d Gateway API CRDs
- Creates 4 base manifests: `InferencePool`, `InferenceModel`, EPP `Deployment`, `HTTPRoute`
- Implements 6 integration tests validating manifest structure and cross-reference consistency (shared `llm-pool` name)

Closes #131

## Test plan

- [x] `cargo test -p llm-d-validation` — all 6 tests pass
- [x] `cargo clippy -p llm-d-validation -- -D warnings` — clean
- [x] `cargo fmt --check -p llm-d-validation` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)