### PR TITLE
feat: add vLLM/llm-d module with AsyncLanguageModel + EmbeddingProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,6 +1058,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3768,6 +3778,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deepsize"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5114,6 +5142,7 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "web-sys",
+ "wiremock",
 ]
 
 [[package]]
@@ -13325,6 +13354,29 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/graphrag-core/Cargo.toml
+++ b/graphrag-core/Cargo.toml
@@ -99,6 +99,7 @@ corpus-processing = ["tracing", "async"]  # Requires tracing for logging and asy
 
 # LLM integrations
 ollama = ["ollama-rs", "async"]        # Ollama LLM support (requires async)
+vllm = ["ureq", "async"]              # vLLM / llm-d support (requires async + ureq)
 
 # Platform-specific features
 wasm = ["wasm-bindgen", "web-sys", "js-sys", "serde-wasm-bindgen", "getrandom"] # Browser WASM compatibility
@@ -237,6 +238,7 @@ getrandom = { version = "0.2", features = ["js"] }
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 pretty_assertions = "1.4"
+wiremock = "0.6"
 proptest = "1.4"
 tempfile = "3.8"
 

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -78,6 +78,9 @@ pub mod builder;
 pub mod summarization;
 /// Ollama LLM integration
 pub mod ollama;
+/// vLLM / llm-d LLM integration
+#[cfg(feature = "vllm")]
+pub mod vllm;
 /// Natural language processing utilities
 pub mod nlp;
 /// Embedding generation and providers

--- a/graphrag-core/src/vllm/mod.rs
+++ b/graphrag-core/src/vllm/mod.rs
@@ -1,0 +1,346 @@
+//! vLLM / llm-d LLM integration
+//!
+//! This module provides integration with vLLM and llm-d inference servers
+//! via their OpenAI-compatible API.
+
+use crate::core::{GraphRAGError, Result};
+
+/// vLLM configuration
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct VllmConfig {
+    /// Enable vLLM integration
+    pub enabled: bool,
+    /// Base URL of the vLLM server (e.g. "http://localhost:8000")
+    pub base_url: String,
+    /// Model identifier
+    pub model: String,
+    /// Optional API key for authenticated deployments
+    pub api_key: Option<String>,
+    /// Timeout in seconds
+    pub timeout_seconds: u64,
+    /// Maximum tokens to generate
+    pub max_tokens: Option<u32>,
+    /// Temperature for generation (0.0 - 2.0)
+    pub temperature: Option<f32>,
+}
+
+impl Default for VllmConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            base_url: "http://localhost:8000".to_string(),
+            model: "meta-llama/Llama-3.1-8B-Instruct".to_string(),
+            api_key: None,
+            timeout_seconds: 30,
+            max_tokens: Some(2000),
+            temperature: Some(0.7),
+        }
+    }
+}
+
+/// vLLM client for LLM inference via the OpenAI-compatible API
+#[derive(Debug, Clone)]
+pub struct VllmClient {
+    config: VllmConfig,
+    #[cfg(feature = "ureq")]
+    client: ureq::Agent,
+}
+
+impl VllmClient {
+    /// Create a new vLLM client
+    pub fn new(config: VllmConfig) -> Self {
+        Self {
+            config: config.clone(),
+            #[cfg(feature = "ureq")]
+            client: ureq::AgentBuilder::new()
+                .timeout(std::time::Duration::from_secs(config.timeout_seconds))
+                .build(),
+        }
+    }
+
+    /// Access the config
+    pub fn config(&self) -> &VllmConfig {
+        &self.config
+    }
+
+    /// Generate a chat completion using the OpenAI-compatible endpoint.
+    #[cfg(feature = "ureq")]
+    pub fn chat_completion(&self, prompt: &str) -> Result<String> {
+        let endpoint = format!("{}/v1/chat/completions", self.config.base_url);
+
+        let mut request_body = serde_json::json!({
+            "model": self.config.model,
+            "messages": [
+                {"role": "user", "content": prompt}
+            ],
+            "stream": false,
+        });
+
+        if let Some(max_tokens) = self.config.max_tokens {
+            request_body["max_tokens"] = serde_json::json!(max_tokens);
+        }
+        if let Some(temperature) = self.config.temperature {
+            request_body["temperature"] = serde_json::json!(temperature);
+        }
+
+        let mut req = self
+            .client
+            .post(&endpoint)
+            .set("Content-Type", "application/json");
+
+        if let Some(ref api_key) = self.config.api_key {
+            req = req.set("Authorization", &format!("Bearer {api_key}"));
+        }
+
+        let response = req.send_json(&request_body).map_err(|e| {
+            GraphRAGError::Generation {
+                message: format!("vLLM API request failed: {e}"),
+            }
+        })?;
+
+        let json_response: serde_json::Value =
+            response.into_json().map_err(|e| GraphRAGError::Generation {
+                message: format!("Failed to parse vLLM response: {e}"),
+            })?;
+
+        // OpenAI format: choices[0].message.content
+        json_response["choices"]
+            .as_array()
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice["message"]["content"].as_str())
+            .map(Self::strip_think_tags)
+            .ok_or_else(|| GraphRAGError::Generation {
+                message: format!("Invalid vLLM response format: {json_response:?}"),
+            })
+    }
+
+    /// Generate embeddings using the OpenAI-compatible endpoint.
+    #[cfg(feature = "ureq")]
+    pub fn embeddings(&self, inputs: &[&str]) -> Result<Vec<Vec<f32>>> {
+        let endpoint = format!("{}/v1/embeddings", self.config.base_url);
+
+        let input_value = if inputs.len() == 1 {
+            serde_json::json!(inputs[0])
+        } else {
+            serde_json::json!(inputs)
+        };
+
+        let request_body = serde_json::json!({
+            "model": self.config.model,
+            "input": input_value,
+        });
+
+        let mut req = self
+            .client
+            .post(&endpoint)
+            .set("Content-Type", "application/json");
+
+        if let Some(ref api_key) = self.config.api_key {
+            req = req.set("Authorization", &format!("Bearer {api_key}"));
+        }
+
+        let response = req.send_json(&request_body).map_err(|e| {
+            GraphRAGError::Generation {
+                message: format!("vLLM embeddings request failed: {e}"),
+            }
+        })?;
+
+        let json_response: serde_json::Value =
+            response.into_json().map_err(|e| GraphRAGError::Generation {
+                message: format!("Failed to parse vLLM embeddings response: {e}"),
+            })?;
+
+        json_response["data"]
+            .as_array()
+            .map(|entries| {
+                entries.iter()
+                    .filter_map(|item| {
+                        item["embedding"].as_array().map(|emb| {
+                            emb.iter()
+                                .filter_map(|v| v.as_f64().map(|f| f as f32))
+                                .collect()
+                        })
+                    })
+                    .collect()
+            })
+            .ok_or_else(|| GraphRAGError::Generation {
+                message: format!("Invalid embeddings response: {json_response:?}"),
+            })
+    }
+
+    /// Generate chat completion (fallback when ureq feature is disabled)
+    #[cfg(not(feature = "ureq"))]
+    pub fn chat_completion(&self, _prompt: &str) -> Result<String> {
+        Err(GraphRAGError::Generation {
+            message: "ureq feature required for vLLM integration".to_string(),
+        })
+    }
+
+    /// Generate embeddings (fallback when ureq feature is disabled)
+    #[cfg(not(feature = "ureq"))]
+    pub fn embeddings(&self, _inputs: &[&str]) -> Result<Vec<Vec<f32>>> {
+        Err(GraphRAGError::Generation {
+            message: "ureq feature required for vLLM integration".to_string(),
+        })
+    }
+
+    /// Remove `<think>...</think>` tags from LLM output (Qwen3 and similar models).
+    fn strip_think_tags(text: &str) -> String {
+        let mut result = text.to_string();
+        while let Some(start) = result.find("<think>") {
+            if let Some(end) = result[start..].find("</think>") {
+                let end_pos = start + end + "</think>".len();
+                result.replace_range(start..end_pos, "");
+            } else {
+                result.replace_range(start..start + "<think>".len(), "");
+                break;
+            }
+        }
+        result.trim().to_string()
+    }
+}
+
+/// Async vLLM generator implementing `AsyncLanguageModel`.
+#[cfg(feature = "async-traits")]
+pub struct AsyncVllmGenerator {
+    client: VllmClient,
+}
+
+#[cfg(feature = "async-traits")]
+impl AsyncVllmGenerator {
+    /// Create a new async vLLM generator
+    pub fn new(config: VllmConfig) -> Self {
+        Self {
+            client: VllmClient::new(config),
+        }
+    }
+}
+
+#[cfg(feature = "async-traits")]
+#[async_trait::async_trait]
+impl crate::core::traits::AsyncLanguageModel for AsyncVllmGenerator {
+    type Error = GraphRAGError;
+
+    async fn complete(&self, prompt: &str) -> Result<String> {
+        self.client.chat_completion(prompt)
+    }
+
+    async fn complete_with_params(
+        &self,
+        prompt: &str,
+        _params: crate::core::traits::GenerationParams,
+    ) -> Result<String> {
+        self.client.chat_completion(prompt)
+    }
+
+    async fn is_available(&self) -> bool {
+        self.client.config.enabled
+    }
+
+    async fn model_info(&self) -> crate::core::traits::ModelInfo {
+        crate::core::traits::ModelInfo {
+            name: self.client.config.model.clone(),
+            version: None,
+            max_context_length: Some(8192),
+            supports_streaming: false,
+        }
+    }
+}
+
+/// vLLM embedding provider implementing `EmbeddingProvider`.
+#[cfg(feature = "async-traits")]
+pub struct VllmEmbeddingProvider {
+    client: VllmClient,
+    dimensions: usize,
+    initialized: bool,
+}
+
+#[cfg(feature = "async-traits")]
+impl VllmEmbeddingProvider {
+    /// Create a new vLLM embedding provider
+    pub fn new(config: VllmConfig, dimensions: usize) -> Self {
+        Self {
+            client: VllmClient::new(config),
+            dimensions,
+            initialized: false,
+        }
+    }
+}
+
+#[cfg(feature = "async-traits")]
+#[async_trait::async_trait]
+impl crate::embeddings::EmbeddingProvider for VllmEmbeddingProvider {
+    async fn initialize(&mut self) -> Result<()> {
+        self.initialized = true;
+        Ok(())
+    }
+
+    async fn embed(&self, text: &str) -> Result<Vec<f32>> {
+        let results = self.client.embeddings(&[text])?;
+        results
+            .into_iter()
+            .next()
+            .ok_or_else(|| GraphRAGError::Generation {
+                message: "No embedding returned".to_string(),
+            })
+    }
+
+    async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        self.client.embeddings(texts)
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+
+    fn is_available(&self) -> bool {
+        self.client.config.enabled
+    }
+
+    fn provider_name(&self) -> &str {
+        "vllm"
+    }
+}
+
+/// Sync adapter for using `VllmClient` as an `LLMInterface` (e.g. for `AnswerGenerator`).
+#[cfg(feature = "async")]
+pub struct VllmLLMAdapter {
+    client: VllmClient,
+}
+
+#[cfg(feature = "async")]
+impl VllmLLMAdapter {
+    /// Create a new sync adapter wrapping a VllmClient
+    pub fn new(config: VllmConfig) -> Self {
+        Self {
+            client: VllmClient::new(config),
+        }
+    }
+}
+
+#[cfg(feature = "async")]
+impl crate::generation::LLMInterface for VllmLLMAdapter {
+    fn generate_response(&self, prompt: &str) -> Result<String> {
+        self.client.chat_completion(prompt)
+    }
+
+    fn generate_summary(&self, content: &str, max_length: usize) -> Result<String> {
+        let prompt = format!(
+            "Summarize the following in at most {max_length} characters:\n\n{content}"
+        );
+        self.client.chat_completion(&prompt)
+    }
+
+    fn extract_key_points(&self, content: &str, num_points: usize) -> Result<Vec<String>> {
+        let prompt = format!(
+            "Extract {num_points} key points from:\n\n{content}\n\nReturn one point per line."
+        );
+        let response = self.client.chat_completion(&prompt)?;
+        Ok(response
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .take(num_points)
+            .map(String::from)
+            .collect())
+    }
+}

--- a/graphrag-core/tests/vllm_integration_tests.rs
+++ b/graphrag-core/tests/vllm_integration_tests.rs
@@ -1,0 +1,324 @@
+//! Integration tests for the vLLM / llm-d module.
+//!
+//! All tests use wiremock — no real LLM calls are made.
+
+#[cfg(feature = "vllm")]
+mod vllm_tests {
+    use graphrag_core::core::traits::{AsyncLanguageModel, GenerationParams};
+    use graphrag_core::embeddings::EmbeddingProvider;
+    use graphrag_core::vllm::{AsyncVllmGenerator, VllmConfig, VllmEmbeddingProvider};
+    use serde_json::json;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn make_config(base_url: &str) -> VllmConfig {
+        VllmConfig {
+            enabled: true,
+            base_url: base_url.to_string(),
+            model: "test-model".to_string(),
+            api_key: None,
+            timeout_seconds: 5,
+            max_tokens: Some(100),
+            temperature: Some(0.7),
+        }
+    }
+
+    fn chat_response(content: &str) -> serde_json::Value {
+        json!({
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+        })
+    }
+
+    fn embedding_response(embeddings: &[Vec<f32>]) -> serde_json::Value {
+        let data: Vec<_> = embeddings
+            .iter()
+            .enumerate()
+            .map(|(i, emb)| {
+                json!({
+                    "object": "embedding",
+                    "index": i,
+                    "embedding": emb
+                })
+            })
+            .collect();
+        json!({
+            "object": "list",
+            "data": data,
+            "model": "test-model",
+            "usage": {"prompt_tokens": 5, "total_tokens": 5}
+        })
+    }
+
+    // ─── Chat Completion Tests ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_vllm_generator_complete_returns_content() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(chat_response("Hello from vLLM!")),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let gen = AsyncVllmGenerator::new(make_config(&mock_server.uri()));
+        let result = gen.complete("Hi").await;
+
+        assert!(result.is_ok(), "complete failed: {:?}", result.err());
+        assert_eq!(result.unwrap(), "Hello from vLLM!");
+    }
+
+    #[tokio::test]
+    async fn test_vllm_generator_complete_with_params() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(chat_response("Parameterized response")),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let gen = AsyncVllmGenerator::new(make_config(&mock_server.uri()));
+        let params = GenerationParams {
+            temperature: Some(0.5),
+            max_tokens: Some(50usize),
+            top_p: None,
+            stop_sequences: None,
+        };
+        let result = gen.complete_with_params("Prompt", params).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "Parameterized response");
+    }
+
+    #[tokio::test]
+    async fn test_vllm_generator_is_available_when_enabled() {
+        let gen = AsyncVllmGenerator::new(VllmConfig {
+            enabled: true,
+            ..VllmConfig::default()
+        });
+        assert!(gen.is_available().await);
+    }
+
+    #[tokio::test]
+    async fn test_vllm_generator_not_available_when_disabled() {
+        let gen = AsyncVllmGenerator::new(VllmConfig {
+            enabled: false,
+            ..VllmConfig::default()
+        });
+        assert!(!gen.is_available().await);
+    }
+
+    #[tokio::test]
+    async fn test_vllm_model_info_returns_configured_name() {
+        let gen = AsyncVllmGenerator::new(VllmConfig {
+            model: "my-custom-model".to_string(),
+            ..VllmConfig::default()
+        });
+        let info = gen.model_info().await;
+        assert_eq!(info.name, "my-custom-model");
+    }
+
+    #[tokio::test]
+    async fn test_vllm_generator_returns_error_on_5xx() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let gen = AsyncVllmGenerator::new(make_config(&mock_server.uri()));
+        let result = gen.complete("fail").await;
+
+        assert!(result.is_err(), "should return error on 500");
+    }
+
+    #[tokio::test]
+    async fn test_vllm_generator_handles_timeout() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(chat_response("delayed"))
+                    .set_delay(std::time::Duration::from_secs(10)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let config = VllmConfig {
+            timeout_seconds: 1, // 1 second timeout
+            ..make_config(&mock_server.uri())
+        };
+        let gen = AsyncVllmGenerator::new(config);
+        let result = gen.complete("timeout test").await;
+
+        assert!(result.is_err(), "should timeout");
+    }
+
+    #[tokio::test]
+    async fn test_vllm_generator_sends_api_key_header() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(header("Authorization", "Bearer test-secret-key"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(chat_response("authed response")),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = VllmConfig {
+            api_key: Some("test-secret-key".to_string()),
+            ..make_config(&mock_server.uri())
+        };
+        let gen = AsyncVllmGenerator::new(config);
+        let result = gen.complete("auth test").await;
+
+        assert!(result.is_ok(), "authed request should succeed: {:?}", result.err());
+        assert_eq!(result.unwrap(), "authed response");
+    }
+
+    // ─── Embedding Tests ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_vllm_embedding_single_input() {
+        let mock_server = MockServer::start().await;
+
+        let expected_embedding = vec![0.1f32, 0.2, 0.3, 0.4];
+
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(embedding_response(&[expected_embedding.clone()])),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut provider = VllmEmbeddingProvider::new(make_config(&mock_server.uri()), 4);
+        provider.initialize().await.unwrap();
+
+        let result = provider.embed("test text").await;
+        assert!(result.is_ok(), "embed failed: {:?}", result.err());
+
+        let embedding = result.unwrap();
+        assert_eq!(embedding.len(), 4);
+        assert!((embedding[0] - 0.1).abs() < f32::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn test_vllm_embedding_batch() {
+        let mock_server = MockServer::start().await;
+
+        let embeddings = vec![
+            vec![0.1f32, 0.2, 0.3],
+            vec![0.4, 0.5, 0.6],
+        ];
+
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(embedding_response(&embeddings)),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut provider = VllmEmbeddingProvider::new(make_config(&mock_server.uri()), 3);
+        provider.initialize().await.unwrap();
+
+        let result = provider.embed_batch(&["text1", "text2"]).await;
+        assert!(result.is_ok(), "batch embed failed: {:?}", result.err());
+
+        let batch = result.unwrap();
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[0].len(), 3);
+        assert_eq!(batch[1].len(), 3);
+    }
+
+    // ─── Pipeline Integration Test ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_rag_pipeline_with_vllm_generation() {
+        use graphrag_core::generation::{AnswerGenerator, GenerationConfig};
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(chat_response(
+                    "Machine learning is a subset of AI that enables systems to learn from data.",
+                )),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let config = make_config(&mock_server.uri());
+        let adapter = graphrag_core::vllm::VllmLLMAdapter::new(config);
+
+        let gen_config = GenerationConfig::default();
+        let generator = AnswerGenerator::new(Box::new(adapter), gen_config);
+        assert!(
+            generator.is_ok(),
+            "AnswerGenerator creation should succeed"
+        );
+    }
+
+    // ─── Think Tag Stripping Test ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_vllm_generator_strips_think_tags() {
+        let mock_server = MockServer::start().await;
+
+        let think_response = "<think>Let me reason about this...</think>The answer is 42.";
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(chat_response(think_response)),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let gen = AsyncVllmGenerator::new(make_config(&mock_server.uri()));
+        let result = gen.complete("question").await;
+
+        assert!(result.is_ok());
+        let answer = result.unwrap();
+        assert!(
+            !answer.contains("<think>"),
+            "think tags should be stripped, got: {answer}"
+        );
+        assert!(
+            answer.contains("The answer is 42"),
+            "content after think tags should remain, got: {answer}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- New `graphrag-core/src/vllm/` module implementing OpenAI-compatible API integration for vLLM and llm-d inference backends
- `VllmClient` — sync HTTP client for `/v1/chat/completions` and `/v1/embeddings` with API key auth, timeout, and think-tag stripping
- `AsyncVllmGenerator` — implements `AsyncLanguageModel` trait
- `VllmEmbeddingProvider` — implements `EmbeddingProvider` trait
- `VllmLLMAdapter` — sync bridge implementing `LLMInterface` for use with `AnswerGenerator`
- Feature-gated behind `vllm = ["ureq", "async"]`
- **12 wiremock-based integration tests** — zero real LLM calls

## Test plan
- [x] `cargo test --features vllm -p graphrag-core --test vllm_integration_tests` — 12/12 pass
- [x] Zero clippy issues in vllm module
- [x] Existing tests unaffected (feature-gated module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)