### PR TITLE
chore: update nix cache config and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
-
-      - name: Configure Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v7
+      - name: Setup Nix + Cache
+        uses: stevedores-org/nix-cache/.github/actions/setup@develop
+        with:
+          push: ${{ github.event_name == 'push' }}
+          cache-auth-token: ${{ secrets.CACHE_AUTH_TOKEN }}
+          signing-secret-key: ${{ secrets.NIX_SIGNING_SECRET_KEY }}
 
       - name: Flake check
         run: nix flake check --print-build-logs
@@ -33,3 +34,9 @@ jobs:
 
       - name: SurrealDB storage tests
         run: nix develop --command cargo test -p graphrag-core --features "surrealdb-storage" surrealdb
+
+      - name: Push to cache
+        if: github.event_name == 'push'
+        uses: stevedores-org/nix-cache/.github/actions/push@develop
+        with:
+          paths: .#default

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,8 @@
   # flake.nix and flake.lock files before merging.
 
   nixConfig = {
-    extra-substituters = [ "https://nix-cache.stevedores.org/stevedores" ];
-    extra-trusted-substituters = [ "https://nix-cache.stevedores.org/stevedores" ];
+    extra-substituters = [ "https://nix-cache.stevedores.org" ];
+    extra-trusted-public-keys = [ "stevedores-cache-1:bXLxkipycRWproIJnk8pPWNFdgVfeV+I2mJXCoW4/ag=" ];
   };
 
   # NOTE: Inputs are pinned to exact commits via flake.lock (committed to repo).
@@ -125,9 +125,6 @@
             wasm-bindgen-cli
             trunk
 
-            # Nix cache
-            attic-client
-
             # Bun (for docs-site)
             bun
 
@@ -153,10 +150,6 @@
             echo "  just doc        # docs build"
             echo "  just ci         # full local CI"
             echo "  just flake-check"
-            echo ""
-            echo "Nix Cache (Attic):"
-            echo "  attic login stevedores https://nix-cache.stevedores.org \$ATTIC_TOKEN"
-            echo "  attic push stevedores <store-path>"
             echo ""
           '';
         };


### PR DESCRIPTION
## Summary
- Fix substituter URL and add `stevedores-cache-1` trusted public key
- Remove `attic-client` from devShell and attic references from shellHook
- Replace DeterminateSystems Nix install + magic cache with `stevedores-org/nix-cache` composite actions
- Add cache push step on merge

Refs stevedores-org/nix-cache#3, stevedores-org/nix-cache#10

🤖 Generated with [Claude Code](https://claude.com/claude-code)