### PR TITLE
Fix flake substituter URL, add cache CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Install Nix with the org's substituter pre-configured as trusted.
+      # The flake.nix's nixConfig.extra-substituters is otherwise ignored
+      # as "untrusted flake configuration" — only nix.conf entries from a
+      # trusted source (here: the installer's extra-conf, which writes
+      # /etc/nix/nix.conf as root) are honored.
+      #
+      # We deliberately do NOT use DeterminateSystems/magic-nix-cache-action.
+      # It depends on FlakeHub authentication, which the org doesn't run, so
+      # every PR was failing with "Unable to authenticate to FlakeHub" and
+      # cascading "substituter disabled" errors. The org's own cache replaces
+      # that role.
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v14
-
-      - name: Configure Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v7
+        with:
+          extra-conf: |
+            extra-substituters = https://nix-cache.stevedores.org/
+            extra-trusted-substituters = https://nix-cache.stevedores.org/
+            extra-trusted-public-keys = stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A=
 
       - name: Flake check
         run: nix flake check --print-build-logs

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -1,0 +1,91 @@
+name: nix-cache
+
+# Builds the flake and pushes the resulting closure (signed) to
+# nix-cache.stevedores.org so other developers and CI runs get cache hits
+# instead of rebuilding from source.
+#
+# Required repo/org secrets:
+#   NIX_CACHE_SIGNING_KEY  — full content of the stevedores-1.secret file
+#                            (format: "stevedores-1:<base64>")
+#   NIX_CACHE_AUTH_TOKEN   — any non-empty string (Worker only checks header
+#                            presence today; tighten if/when the Worker is
+#                            upgraded to validate tokens)
+
+on:
+  push:
+    branches: [main, develop]
+  workflow_dispatch:
+
+concurrency:
+  group: nix-cache-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Determinate Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+
+      - name: Build outputs to cache
+        run: |
+          set -euo pipefail
+          system=$(nix eval --impure --raw --expr 'builtins.currentSystem')
+          : > /tmp/built-paths
+
+          # Default package (the main artifact)
+          nix build .#default --no-link --print-out-paths >> /tmp/built-paths
+
+          # Dev shell (so downstream `nix develop` is a download not a build)
+          nix build ".#devShells.${system}.default" --no-link --print-out-paths >> /tmp/built-paths || true
+
+          # All checks (clippy, tests, fmt, etc.) — populates cache for `nix flake check`
+          checks=$(nix flake show --json --quiet 2>/dev/null \
+                    | jq -r --arg s "$system" '.checks[$s] // {} | keys[]' 2>/dev/null || true)
+          for check in $checks; do
+            nix build ".#checks.${system}.${check}" --no-link --print-out-paths >> /tmp/built-paths || true
+          done
+
+          echo "--- paths to sign and push ---"
+          cat /tmp/built-paths
+
+      - name: Sign and push to nix-cache.stevedores.org
+        env:
+          NIX_CACHE_SIGNING_KEY: ${{ secrets.NIX_CACHE_SIGNING_KEY }}
+          NIX_CACHE_AUTH_TOKEN: ${{ secrets.NIX_CACHE_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${NIX_CACHE_SIGNING_KEY:-}" ]; then
+            echo "::warning::NIX_CACHE_SIGNING_KEY not set — skipping push"
+            exit 0
+          fi
+
+          # Stage signing key (file format: "name:base64-secret")
+          install -m 600 /dev/null /tmp/nix-cache.key
+          printf '%s\n' "$NIX_CACHE_SIGNING_KEY" > /tmp/nix-cache.key
+
+          # Stage netrc for cache auth
+          install -m 600 /dev/null /tmp/nix-cache.netrc
+          cat > /tmp/nix-cache.netrc <<EOF
+          machine nix-cache.stevedores.org
+          password ${NIX_CACHE_AUTH_TOKEN:-anything}
+          EOF
+
+          # Sign all built paths recursively (closure)
+          xargs -a /tmp/built-paths nix store sign \
+            --key-file /tmp/nix-cache.key \
+            --recursive
+
+          # Push closure to cache
+          xargs -a /tmp/built-paths nix copy \
+            --to "https://nix-cache.stevedores.org/" \
+            --option netrc-file /tmp/nix-cache.netrc
+
+      - name: Cleanup secrets
+        if: always()
+        run: rm -f /tmp/nix-cache.key /tmp/nix-cache.netrc

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -37,17 +37,20 @@ jobs:
           system=$(nix eval --impure --raw --expr 'builtins.currentSystem')
           : > /tmp/built-paths
 
-          # Default package (the main artifact)
+          # Default package — the main artifact. Failures here fail the job.
           nix build .#default --no-link --print-out-paths >> /tmp/built-paths
 
-          # Dev shell (so downstream `nix develop` is a download not a build)
-          nix build ".#devShells.${system}.default" --no-link --print-out-paths >> /tmp/built-paths || true
+          # Dev shell — failures here fail the job (broken dev shell is a real bug).
+          nix build ".#devShells.${system}.default" --no-link --print-out-paths >> /tmp/built-paths
 
-          # All checks (clippy, tests, fmt, etc.) — populates cache for `nix flake check`
+          # All checks (clippy, tests, fmt, etc.) — failures here fail the job
+          # so a broken clippy/test/fmt does NOT silently produce a green cache push.
+          # `nix flake show` enumeration is best-effort; if the flake has no checks
+          # output, the loop just does nothing.
           checks=$(nix flake show --json --quiet 2>/dev/null \
                     | jq -r --arg s "$system" '.checks[$s] // {} | keys[]' 2>/dev/null || true)
           for check in $checks; do
-            nix build ".#checks.${system}.${check}" --no-link --print-out-paths >> /tmp/built-paths || true
+            nix build ".#checks.${system}.${check}" --no-link --print-out-paths >> /tmp/built-paths
           done
 
           echo "--- paths to sign and push ---"
@@ -69,22 +72,27 @@ jobs:
           install -m 600 /dev/null /tmp/nix-cache.key
           printf '%s\n' "$NIX_CACHE_SIGNING_KEY" > /tmp/nix-cache.key
 
-          # Stage netrc for cache auth
+          # Stage netrc for cache auth. The `login` field is required for
+          # libcurl/Nix to emit an Authorization header on URLs without an
+          # in-URL username — without it, the entry is silently skipped.
           install -m 600 /dev/null /tmp/nix-cache.netrc
           cat > /tmp/nix-cache.netrc <<EOF
           machine nix-cache.stevedores.org
+          login stevedores
           password ${NIX_CACHE_AUTH_TOKEN:-anything}
           EOF
 
-          # Sign all built paths recursively (closure)
-          xargs -a /tmp/built-paths nix store sign \
+          # Sign all built paths recursively (closure). Use stdin redirection
+          # rather than `xargs -a` so this works on both GNU (Linux) and BSD
+          # (macOS) xargs.
+          xargs nix store sign \
             --key-file /tmp/nix-cache.key \
-            --recursive
+            --recursive < /tmp/built-paths
 
-          # Push closure to cache
-          xargs -a /tmp/built-paths nix copy \
+          # Push closure to cache.
+          xargs nix copy \
             --to "https://nix-cache.stevedores.org/" \
-            --option netrc-file /tmp/nix-cache.netrc
+            --option netrc-file /tmp/nix-cache.netrc < /tmp/built-paths
 
       - name: Cleanup secrets
         if: always()

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1777830388,
+        "narHash": "sha256-2uoQAqUk2H0ijQtGiWAyNeQYGYc6yfAcRRLlJAz4Gp8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "d459c1350e96ce1a7e3859c513ef5e9869d67d6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777864665,
+        "narHash": "sha256-oE4lnjiBa3uE+dP9jM0jFzofP1xYIlK6IQBjLfWjH04=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "669151bbc7f2416b622af2f48e9136e2c9da5530",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,11 @@
   # flake.nix and flake.lock files before merging.
 
   nixConfig = {
-    extra-substituters = [ "https://nix-cache.stevedores.org/stevedores" ];
-    extra-trusted-substituters = [ "https://nix-cache.stevedores.org/stevedores" ];
+    extra-substituters = [ "https://nix-cache.stevedores.org/" ];
+    extra-trusted-substituters = [ "https://nix-cache.stevedores.org/" ];
+    extra-trusted-public-keys = [
+      "stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A="
+    ];
   };
 
   # NOTE: Inputs are pinned to exact commits via flake.lock (committed to repo).


### PR DESCRIPTION
## Summary
- **Substituter URL fix**: was `https://nix-cache.stevedores.org/stevedores` — that path 404s on the Cloudflare-Worker-backed cache (flat single-bucket, no multi-tenant routing). Changed to root URL. **Without this, every `nix develop` silently rebuilds from source.**
- **`stevedores-1` org-wide signing key** added to `extra-trusted-public-keys`.
- **`flake.lock` (new)**: the existing flake comment claimed inputs were "pinned to exact commits via flake.lock (committed to repo)" but the file was never committed. Now it is.
- **`.github/workflows/nix-cache.yml` (new)**: build + sign + push to cache.

## Required secrets
- `NIX_CACHE_SIGNING_KEY` — content of `stevedores-1.secret`
- `NIX_CACHE_AUTH_TOKEN` — any non-empty string

## Test plan
- [ ] Workflow runs on push to `main` and pushes to cache
- [ ] Subsequent `nix develop` on a clean machine pulls from cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)