### PR TITLE
fix(flake): drop invalid --no-run from benches build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,7 @@
 
           benches = craneLib.buildPackage (commonArgs // {
             inherit cargoArtifacts;
-            cargoExtraArgs = "--workspace --benches --no-run";
+            cargoExtraArgs = "--workspace --benches";
           });
 
           doc = craneLib.cargoDoc (commonArgs // {


### PR DESCRIPTION
## Summary

Unblocks the long-failing \`nix-check\` CI job (every push to \`develop\` and \`main\` has been red since the cargo upgrade; release PR #162 is currently blocked on this).

## Root cause

The \`benches\` check in \`flake.nix\` calls \`craneLib.buildPackage\` with:

\`\`\`nix
cargoExtraArgs = \"--workspace --benches --no-run\";
\`\`\`

\`craneLib.buildPackage\` invokes \`cargo build\` — and \`--no-run\` is only a valid flag for \`cargo test\`. Newer cargo rejects it:

\`\`\`
+++ command cargo build --release --message-format json-render-diagnostics --workspace --benches --no-run
> error: unexpected argument '--no-run' found
\`\`\`

That fails the \`benches\` check, which cancels the \`workspace\` check that runs after it, so the entire \`nix-check\` job exits 1.

## Fix

Drop \`--no-run\` — it was redundant. \`cargo build --benches\` already compiles benchmarks without executing them, which is exactly the \"benches compile cleanly\" gate this check was meant to enforce.

## Verification

Can't fully verify locally without a Nix toolchain, but this is the exact error line emitted in the CI log (e.g. run 24946445215). The fix is mechanical and the surrounding diff is one character of change (drop \` --no-run\` from the args string).

## Followups

The \`nix-check\` job also emits several non-fatal noise items:
1. **FlakeHub auth warnings** from \`magic-nix-cache-action@v7\` (\`Cannot find netrc credentials for https://api.flakehub.com/\`). The action runs without caching when unauthenticated. Either register the org with FlakeHub or migrate to \`cachix/cachix-action\` for free OSS caching. Worth a separate issue.
2. **Node 20 deprecation warnings** on \`actions/checkout@v4\`, \`magic-nix-cache-action@v7\`, \`nix-installer-action@v14\`. Same June 2 / Sept 16 deadlines as I just bumped on oxidizedMLX in PR #142. Worth a separate issue.

Neither blocks this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)