### PR TITLE
fix(ci): bring substituter fix from #163 to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Install Nix with the org's substituter pre-configured as trusted.
+      # The flake.nix's nixConfig.extra-substituters is otherwise ignored
+      # as "untrusted flake configuration" — only nix.conf entries from a
+      # trusted source (here: the installer's extra-conf, which writes
+      # /etc/nix/nix.conf as root) are honored.
+      #
+      # We deliberately do NOT use DeterminateSystems/magic-nix-cache-action.
+      # It depends on FlakeHub authentication, which the org doesn't run, so
+      # every PR was failing with "Unable to authenticate to FlakeHub" and
+      # cascading "substituter disabled" errors. The org's own cache replaces
+      # that role.
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v14
-
-      - name: Configure Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v7
+        with:
+          extra-conf: |
+            extra-substituters = https://nix-cache.stevedores.org/
+            extra-trusted-substituters = https://nix-cache.stevedores.org/
+            extra-trusted-public-keys = stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A=
 
       - name: Flake check
         run: nix flake check --print-build-logs

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,11 @@
   # flake.nix and flake.lock files before merging.
 
   nixConfig = {
-    extra-substituters = [ "https://nix-cache.stevedores.org/stevedores" ];
-    extra-trusted-substituters = [ "https://nix-cache.stevedores.org/stevedores" ];
+    extra-substituters = [ "https://nix-cache.stevedores.org/" ];
+    extra-trusted-substituters = [ "https://nix-cache.stevedores.org/" ];
+    extra-trusted-public-keys = [
+      "stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A="
+    ];
   };
 
   # NOTE: Inputs are pinned to exact commits via flake.lock (committed to repo).


### PR DESCRIPTION
## Summary

- Backport the substituter fix that just landed on main as #163 so develop's CI is also green.
- Once green, this clears the way for #162 (release: merge develop into main) to merge cleanly.
- Supersedes #165 (same fix, stale branch).

## Why develop was failing

`DeterminateSystems/magic-nix-cache-action@v7` requires FlakeHub authentication that the org doesn't run. On every PR event the action fails to start its local substituter, then every `nix flake check` fails with:

```
error: substituter 'http://127.0.0.1:<port>' is disabled
```

## What this changes

- **`flake.nix`** — switch substituter URL from the sub-path `nix-cache.stevedores.org/stevedores` to the flat root URL the Cloudflare Worker actually serves, and add the matching `stevedores-1` trusted public key so signatures verify.
- **`.github/workflows/ci.yml`** — drop the magic-nix-cache step. Inline `extra-substituters` / `extra-trusted-public-keys` into the nix-installer-action `extra-conf` so the config lands in `/etc/nix/nix.conf` as root. nix.conf written by root is the only place `trusted` substituter config is honored — `nixConfig` in `flake.nix` is treated as untrusted flake configuration and silently ignored.

This is the same approach that's now live on main (PR #163).

## Test plan

- [ ] `nix-check` passes on this PR
- [ ] `nix flake check` logs show `copying path '...' from 'https://nix-cache.stevedores.org/...'` on cache hit
- [ ] No `substituter '...' is disabled` errors
- [ ] After merge, #162 (release PR) re-runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)