### PR TITLE
test(incremental): gate incremental test files behind the feature

### DIFF
--- a/graphrag-core/tests/incremental_correctness_test.rs
+++ b/graphrag-core/tests/incremental_correctness_test.rs
@@ -4,6 +4,8 @@
 //! to graphs built from scratch, and that delete/rollback operations
 //! maintain consistency.
 
+#![cfg(feature = "incremental")]
+
 use graphrag_core::core::{Entity, EntityId, KnowledgeGraph, Relationship};
 use graphrag_core::graph::incremental::{
     ChangeData, ChangeRecord, ChangeType, ConflictResolver, ConflictStrategy, DeltaStatus,

--- a/graphrag-core/tests/incremental_perf_test.rs
+++ b/graphrag-core/tests/incremental_perf_test.rs
@@ -2,6 +2,8 @@
 //!
 //! Validates that incremental updates cost <5% of a full rebuild.
 
+#![cfg(feature = "incremental")]
+
 use graphrag_core::core::{Entity, EntityId, KnowledgeGraph, Relationship};
 use graphrag_core::graph::incremental::{
     ConflictResolver, ConflictStrategy, IncrementalConfig, IncrementalGraphStore,


### PR DESCRIPTION
## Summary

- `tests/incremental_correctness_test.rs` and `tests/incremental_perf_test.rs` both `use graphrag_core::graph::incremental::ProductionGraphStore;` — but `ProductionGraphStore` is `#[cfg(feature = "incremental")]` at `incremental.rs:1843`.
- Without matching feature gates on the test files, `cargo clippy --all-targets` (what `flake.nix` runs via `craneLib.cargoClippy` with `--all-targets -- -D warnings`) fails with E0432.
- This adds `#![cfg(feature = "incremental")]` to the top of each test file so they're conditionally compiled.

## Why this hasn't bitten anyone yet

The compile error has been masked by the workspace's pre-existing clippy `-D warnings` failures in `graphrag-core` (~51 lints). Clippy stops at the first error category; once a follow-up PR clears the warnings, this E0432 would become the new blocker.

Filing this as a small standalone PR so the clippy cleanup can rebase cleanly on top.

## Test plan

- [ ] `cargo clippy -p graphrag-core --all-targets --no-deps` (default features) no longer reports E0432
- [ ] `cargo test -p graphrag-core --features incremental --test incremental_correctness_test` still runs and passes (the tests themselves are unchanged)
- [ ] CI `nix-check` advances past the previous E0432 wall

🤖 Generated with [Claude Code](https://claude.com/claude-code)