### PR TITLE
fix(flake): drop invalid --no-run from benches build (cherry-pick of #166)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,7 +92,7 @@
 
           benches = craneLib.buildPackage (commonArgs // {
             inherit cargoArtifacts;
-            cargoExtraArgs = "--workspace --benches --no-run";
+            cargoExtraArgs = "--workspace --benches";
           });
 
           doc = craneLib.cargoDoc (commonArgs // {


### PR DESCRIPTION
Cherry-pick of `5bdc7aa` (originally PR #166) from `develop` to `main`. Same pattern as #170 — pulling forward a develop-only fix so `main`'s CI can move past the next failing check.

## What this fixes

After #170 landed, `main`'s post-merge `nix-check` run (`26427298232`) cleared `fmt` and `deps` but failed at `benches` with:

```
cargo-package> error: unexpected argument '--no-run' found
```

`craneLib.buildPackage` invokes `cargo build` (not `cargo test`); `--no-run` is a `cargo test`-only flag. Newer cargo versions reject it. The fix is to drop the redundant `--no-run` — `cargo build --benches` already compiles bench binaries without running them, which is what this check is supposed to verify.

## The diff

```diff
- cargoExtraArgs = "--workspace --benches --no-run";
+ cargoExtraArgs = "--workspace --benches";
```

One line, in `flake.nix`. Identical to `develop`'s state.

## Test plan

- [ ] `checks.x86_64-linux.benches` no longer fails with `unexpected argument '--no-run'`.
- [ ] If a different downstream check (`workspace` / `tests` / `clippy` / `doc`) now surfaces a different develop-only bug, file as the next follow-up. Strongly recommend just landing #162 (develop→main) once we've burned down enough of these.

## Related

- #170 (merged) — the prior cherry-pick of develop-only fixes (Cargo.lock + neural stub + fmt).
- #166 (merged on develop) — the original fix being cherry-picked.
- #162 — release: merge develop into main. Still the right end-state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)