### PR TITLE
fix(graphrag-core): clippy::all + missing_docs cleanup

### DIFF
--- a/graphrag-core/examples/complete_zero_cost_graphrag_demo.rs
+++ b/graphrag-core/examples/complete_zero_cost_graphrag_demo.rs
@@ -431,7 +431,7 @@ async fn test_approach_with_config(
 
         // Create text chunks
         let text_processor = TextProcessor::new(600, 150)?;
-        let chunks = text_processor.chunk_text(&doc)?;
+        let chunks = text_processor.chunk_text(doc)?;
         println!("   Created {} chunks", chunks.len());
 
         // Add document to GraphRAG

--- a/graphrag-core/examples/embeddings_demo.rs
+++ b/graphrag-core/examples/embeddings_demo.rs
@@ -1,13 +1,13 @@
-///! Demonstration of embedding providers in graphrag-core
-///!
-///! This example shows how to use different embedding providers:
-///! - Hugging Face Hub (free, downloadable models)
-///! - OpenAI API
-///! - Voyage AI API
-///! - Cohere API
-///! - Jina AI API
-///! - Mistral AI API
-///! - Together AI API
+//! Demonstration of embedding providers in graphrag-core
+//!
+//! This example shows how to use different embedding providers:
+//! - Hugging Face Hub (free, downloadable models)
+//! - OpenAI API
+//! - Voyage AI API
+//! - Cohere API
+//! - Jina AI API
+//! - Mistral AI API
+//! - Together AI API
 use graphrag_core::embeddings::{EmbeddingConfig, EmbeddingProvider, EmbeddingProviderType};
 
 #[cfg(feature = "huggingface-hub")]

--- a/graphrag-core/examples/embeddings_from_config.rs
+++ b/graphrag-core/examples/embeddings_from_config.rs
@@ -1,12 +1,12 @@
-///! Load embedding configuration from TOML file
-///!
-///! This example demonstrates how to configure embedding providers
-///! using a TOML configuration file.
-///!
-///! Run with:
-///! ```bash
-///! cargo run --example embeddings_from_config --features "ureq,huggingface-hub"
-///! ```
+//! Load embedding configuration from TOML file
+//!
+//! This example demonstrates how to configure embedding providers
+//! using a TOML configuration file.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example embeddings_from_config --features "ureq,huggingface-hub"
+//! ```
 use graphrag_core::embeddings::config::EmbeddingProviderConfig;
 use graphrag_core::embeddings::EmbeddingProvider;
 

--- a/graphrag-core/examples/symposium_trait_based_chunking.rs
+++ b/graphrag-core/examples/symposium_trait_based_chunking.rs
@@ -19,6 +19,7 @@ use graphrag_core::text::RustCodeChunkingStrategy;
 
 /// Metrics for comparing chunking strategies
 #[derive(Debug)]
+#[allow(dead_code)]
 struct ChunkingMetrics {
     strategy_name: String,
     num_chunks: usize,

--- a/graphrag-core/src/config/json5_loader.rs
+++ b/graphrag-core/src/config/json5_loader.rs
@@ -171,7 +171,7 @@ mod tests {
         let config: TestConfig = parse_json5_str(json5_str).unwrap();
         assert_eq!(config.name, "test");
         assert_eq!(config.value, 42);
-        assert_eq!(config.enabled, true);
+        assert!(config.enabled);
     }
 
     #[test]

--- a/graphrag-core/src/config/mod.rs
+++ b/graphrag-core/src/config/mod.rs
@@ -148,8 +148,7 @@ pub struct ZeroCostApproachConfig {
 
 /// Configuration for LazyGraphRAG, an efficient approach for large-scale knowledge graphs.
 /// This configuration enables lazy loading and processing of graph components.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 pub struct LazyGraphRAGConfig {
     /// Whether LazyGraphRAG is enabled
     pub enabled: bool,
@@ -253,8 +252,7 @@ pub struct LazyRelevanceScoringConfig {
 
 /// End-to-End GraphRAG configuration for comprehensive knowledge graph construction.
 /// This configuration enables fine-grained control over the entire pipeline from text to knowledge graph.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 pub struct E2GraphRAGConfig {
     /// Whether the E2E GraphRAG pipeline is enabled
     pub enabled: bool,
@@ -507,8 +505,7 @@ pub struct SearchRankingConfig {
 ///
 /// Enables semantic search using embeddings and similarity scoring
 /// for finding conceptually related content.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 pub struct VectorSearchConfig {
     /// Whether vector similarity search is enabled
     pub enabled: bool,

--- a/graphrag-core/src/config/mod.rs
+++ b/graphrag-core/src/config/mod.rs
@@ -149,6 +149,7 @@ pub struct ZeroCostApproachConfig {
 /// Configuration for LazyGraphRAG, an efficient approach for large-scale knowledge graphs.
 /// This configuration enables lazy loading and processing of graph components.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Default)]
 pub struct LazyGraphRAGConfig {
     /// Whether LazyGraphRAG is enabled
     pub enabled: bool,
@@ -253,6 +254,7 @@ pub struct LazyRelevanceScoringConfig {
 /// End-to-End GraphRAG configuration for comprehensive knowledge graph construction.
 /// This configuration enables fine-grained control over the entire pipeline from text to knowledge graph.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Default)]
 pub struct E2GraphRAGConfig {
     /// Whether the E2E GraphRAG pipeline is enabled
     pub enabled: bool,
@@ -506,6 +508,7 @@ pub struct SearchRankingConfig {
 /// Enables semantic search using embeddings and similarity scoring
 /// for finding conceptually related content.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Default)]
 pub struct VectorSearchConfig {
     /// Whether vector similarity search is enabled
     pub enabled: bool,
@@ -662,18 +665,6 @@ impl Default for ZeroCostApproachConfig {
 }
 
 // Default implementations for sub-configs (simplified for now)
-impl Default for LazyGraphRAGConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            concept_extraction: Default::default(),
-            co_occurrence: Default::default(),
-            indexing: Default::default(),
-            query_expansion: Default::default(),
-            relevance_scoring: Default::default(),
-        }
-    }
-}
 impl Default for ConceptExtractionConfig {
     fn default() -> Self {
         Self {
@@ -729,17 +720,6 @@ impl Default for LazyRelevanceScoringConfig {
             batch_size: 10,
             temperature: 0.2,
             max_tokens_per_score: 30,
-        }
-    }
-}
-impl Default for E2GraphRAGConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            ner_extraction: Default::default(),
-            keyword_extraction: Default::default(),
-            graph_construction: Default::default(),
-            indexing: Default::default(),
         }
     }
 }
@@ -842,11 +822,6 @@ impl Default for HybridStrategyConfig {
                 fallback_to_algorithmic: true,
             },
         }
-    }
-}
-impl Default for VectorSearchConfig {
-    fn default() -> Self {
-        Self { enabled: false }
     }
 }
 impl Default for KeywordSearchConfig {

--- a/graphrag-core/src/config/setconfig.rs
+++ b/graphrag-core/src/config/setconfig.rs
@@ -1775,10 +1775,11 @@ impl SetConfig {
 
     /// Convert to the existing Config format for compatibility
     pub fn to_graphrag_config(&self) -> crate::Config {
-        let mut config = crate::Config::default();
-
         // Map pipeline approach (semantic/algorithmic/hybrid)
-        config.approach = self.mode.approach.clone();
+        let mut config = crate::Config {
+            approach: self.mode.approach.clone(),
+            ..crate::Config::default()
+        };
 
         // Map text processing
         config.text.chunk_size = self.pipeline.text_extraction.chunk_size;

--- a/graphrag-core/src/config/setconfig.rs
+++ b/graphrag-core/src/config/setconfig.rs
@@ -733,7 +733,6 @@ impl AnnProfile {
     }
 }
 
-
 /// Semantic retrieval configuration (vector search)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SemanticRetrievalConfig {
@@ -793,8 +792,7 @@ pub struct SemanticGraphConfig {
 
 /// Algorithmic/Classic NLP pipeline configuration
 /// Uses pattern matching, TF-IDF, and keyword-based methods
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AlgorithmicPipelineConfig {
     /// Enable algorithmic pipeline
     #[serde(default)]
@@ -1602,7 +1600,6 @@ impl Default for SemanticGraphConfig {
         }
     }
 }
-
 
 impl Default for AlgorithmicEmbeddingsConfig {
     fn default() -> Self {

--- a/graphrag-core/src/config/setconfig.rs
+++ b/graphrag-core/src/config/setconfig.rs
@@ -711,10 +711,12 @@ pub struct SemanticEntityConfig {
 /// off between latency and recall.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[derive(Default)]
 pub enum AnnProfile {
     /// Low ef values — minimal latency, lower recall.
     Fast,
     /// Default — good balance between latency and recall.
+    #[default]
     Balanced,
     /// High ef values — maximum recall at the cost of latency.
     RecallMax,
@@ -731,11 +733,6 @@ impl AnnProfile {
     }
 }
 
-impl Default for AnnProfile {
-    fn default() -> Self {
-        AnnProfile::Balanced
-    }
-}
 
 /// Semantic retrieval configuration (vector search)
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -797,6 +794,7 @@ pub struct SemanticGraphConfig {
 /// Algorithmic/Classic NLP pipeline configuration
 /// Uses pattern matching, TF-IDF, and keyword-based methods
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Default)]
 pub struct AlgorithmicPipelineConfig {
     /// Enable algorithmic pipeline
     #[serde(default)]
@@ -1605,17 +1603,6 @@ impl Default for SemanticGraphConfig {
     }
 }
 
-impl Default for AlgorithmicPipelineConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            embeddings: AlgorithmicEmbeddingsConfig::default(),
-            entity_extraction: AlgorithmicEntityConfig::default(),
-            retrieval: AlgorithmicRetrievalConfig::default(),
-            graph_construction: AlgorithmicGraphConfig::default(),
-        }
-    }
-}
 
 impl Default for AlgorithmicEmbeddingsConfig {
     fn default() -> Self {

--- a/graphrag-core/src/core/mod.rs
+++ b/graphrag-core/src/core/mod.rs
@@ -808,11 +808,7 @@ impl KnowledgeGraph {
         } else {
             // Build using triplet matrix first, then convert to CSR
             let mut triplet_mat = sprs::TriMat::new((nodes.len(), nodes.len()));
-            for ((row, col), val) in row_indices
-                .into_iter()
-                .zip(col_indices.into_iter())
-                .zip(values.into_iter())
-            {
+            for ((row, col), val) in row_indices.into_iter().zip(col_indices).zip(values) {
                 triplet_mat.add_triplet(row, col, val);
             }
             triplet_mat.to_csr()

--- a/graphrag-core/src/entity/bidirectional_index.rs
+++ b/graphrag-core/src/entity/bidirectional_index.rs
@@ -326,7 +326,7 @@ impl BidirectionalIndex {
             .collect();
 
         // Sort by chunk count descending
-        common_entities.sort_by(|a, b| b.1.cmp(&a.1));
+        common_entities.sort_by_key(|e| std::cmp::Reverse(e.1));
 
         common_entities
     }
@@ -348,7 +348,7 @@ impl BidirectionalIndex {
             .collect();
 
         // Sort by entity count descending
-        dense_chunks.sort_by(|a, b| b.1.cmp(&a.1));
+        dense_chunks.sort_by_key(|c| std::cmp::Reverse(c.1));
 
         dense_chunks
     }

--- a/graphrag-core/src/entity/gleaning_extractor.rs
+++ b/graphrag-core/src/entity/gleaning_extractor.rs
@@ -307,22 +307,22 @@ impl GleaningEntityExtractor {
     ) -> Result<Vec<Entity>> {
         let mut entities = Vec::new();
 
-        for data in entity_data {
+        for record in entity_data {
             // Generate entity ID
             let entity_id = crate::core::EntityId::new(format!(
                 "{}_{}",
-                data.entity_type,
-                self.normalize_name(&data.name)
+                record.entity_type,
+                self.normalize_name(&record.name)
             ));
 
             // Find mentions in chunk
-            let mentions = self.find_mentions(&data.name, chunk_id, chunk_text);
+            let mentions = self.find_mentions(&record.name, chunk_id, chunk_text);
 
             // Create entity with mentions
             let entity = Entity::new(
                 entity_id,
-                data.name.clone(),
-                data.entity_type.clone(),
+                record.name.clone(),
+                record.entity_type.clone(),
                 0.9, // High confidence since LLM-extracted
             )
             .with_mentions(mentions);
@@ -389,17 +389,17 @@ impl GleaningEntityExtractor {
             name_to_entity.insert(entity.name.to_lowercase(), entity);
         }
 
-        for data in relationship_data {
+        for record in relationship_data {
             // Find source and target entities
-            let source_entity = name_to_entity.get(&data.source.to_lowercase());
-            let target_entity = name_to_entity.get(&data.target.to_lowercase());
+            let source_entity = name_to_entity.get(&record.source.to_lowercase());
+            let target_entity = name_to_entity.get(&record.target.to_lowercase());
 
             if let (Some(source), Some(target)) = (source_entity, target_entity) {
                 let relationship = Relationship {
                     source: source.id.clone(),
                     target: target.id.clone(),
-                    relation_type: data.description.clone(),
-                    confidence: data.strength as f32,
+                    relation_type: record.description.clone(),
+                    confidence: record.strength as f32,
                     context: vec![],
                 };
 
@@ -407,8 +407,8 @@ impl GleaningEntityExtractor {
             } else {
                 tracing::warn!(
                     "Skipping relationship: entity not found. Source: {}, Target: {}",
-                    data.source,
-                    data.target
+                    record.source,
+                    record.target
                 );
             }
         }

--- a/graphrag-core/src/entity/llm_extractor.rs
+++ b/graphrag-core/src/entity/llm_extractor.rs
@@ -297,24 +297,21 @@ impl LLMEntityExtractor {
     ) -> Result<Vec<Entity>> {
         let mut entities = Vec::new();
 
-        for data in entity_data {
+        for record in entity_data {
             // Generate entity ID
             let entity_id = EntityId::new(format!(
                 "{}_{}",
-                data.entity_type,
-                self.normalize_name(&data.name)
+                record.entity_type,
+                self.normalize_name(&record.name)
             ));
 
             // Find mentions in chunk
-            let mentions = self.find_mentions(&data.name, chunk_id, chunk_text);
+            let mentions = self.find_mentions(&record.name, chunk_id, chunk_text);
 
-            // Create entity with mentions
-            // Note: Description is stored in the entity but not used in current Entity struct
-            // We store it in the entity name or as a separate field if needed
             let entity = Entity::new(
                 entity_id,
-                data.name.clone(),
-                data.entity_type.clone(),
+                record.name.clone(),
+                record.entity_type.clone(),
                 0.9, // High confidence since it's LLM-extracted
             )
             .with_mentions(mentions);
@@ -377,17 +374,17 @@ impl LLMEntityExtractor {
             name_to_entity.insert(entity.name.to_lowercase(), entity);
         }
 
-        for data in relationship_data {
+        for record in relationship_data {
             // Find source and target entities
-            let source_entity = name_to_entity.get(&data.source.to_lowercase());
-            let target_entity = name_to_entity.get(&data.target.to_lowercase());
+            let source_entity = name_to_entity.get(&record.source.to_lowercase());
+            let target_entity = name_to_entity.get(&record.target.to_lowercase());
 
             if let (Some(source), Some(target)) = (source_entity, target_entity) {
                 let relationship = Relationship {
                     source: source.id.clone(),
                     target: target.id.clone(),
-                    relation_type: data.description.clone(),
-                    confidence: data.strength as f32,
+                    relation_type: record.description.clone(),
+                    confidence: record.strength as f32,
                     context: vec![], // No context chunks for this relationship
                 };
 
@@ -395,8 +392,8 @@ impl LLMEntityExtractor {
             } else {
                 tracing::warn!(
                     "Skipping relationship: entity not found. Source: {}, Target: {}",
-                    data.source,
-                    data.target
+                    record.source,
+                    record.target
                 );
             }
         }

--- a/graphrag-core/src/entity/llm_extractor.rs
+++ b/graphrag-core/src/entity/llm_extractor.rs
@@ -241,7 +241,7 @@ impl LLMEntityExtractor {
         if let Some(start) = text.find("```json") {
             let json_start = start + 7; // length of ```json
             if let Some(end) = text[json_start..].find("```") {
-                return Some(&text[json_start..json_start + end].trim());
+                return Some(text[json_start..json_start + end].trim());
             }
         }
 

--- a/graphrag-core/src/entity/string_similarity_linker.rs
+++ b/graphrag-core/src/entity/string_similarity_linker.rs
@@ -214,11 +214,11 @@ impl StringSimilarityLinker {
         let mut matrix = vec![vec![0; len2 + 1]; len1 + 1];
 
         // Initialize first row and column
-        for i in 0..=len1 {
-            matrix[i][0] = i;
+        for (i, row) in matrix.iter_mut().enumerate() {
+            row[0] = i;
         }
-        for j in 0..=len2 {
-            matrix[0][j] = j;
+        for (j, cell) in matrix[0].iter_mut().enumerate() {
+            *cell = j;
         }
 
         let s1_chars: Vec<char> = s1.chars().collect();

--- a/graphrag-core/src/entity/string_similarity_linker.rs
+++ b/graphrag-core/src/entity/string_similarity_linker.rs
@@ -605,6 +605,6 @@ mod tests {
         let links = linker.link_entities(&graph).unwrap();
 
         // Should link similar location names
-        assert!(links.len() > 0, "Expected some entities to be linked");
+        assert!(!links.is_empty(), "Expected some entities to be linked");
     }
 }

--- a/graphrag-core/src/evaluation/pipeline_validation.rs
+++ b/graphrag-core/src/evaluation/pipeline_validation.rs
@@ -457,7 +457,7 @@ impl GraphConstructionValidator {
         // Check 2: Reasonable entity-to-chunk ratio
         if chunks > 0 {
             let entities_per_chunk = entities as f64 / chunks as f64;
-            let reasonable = entities_per_chunk >= 0.1 && entities_per_chunk <= 10.0;
+            let reasonable = (0.1..=10.0).contains(&entities_per_chunk);
 
             checks.push(ValidationCheck {
                 name: "entity_chunk_ratio_reasonable".to_string(),
@@ -580,7 +580,7 @@ impl PipelineValidationReport {
     /// Generate a detailed report string
     pub fn detailed_report(&self) -> String {
         let mut report = String::new();
-        report.push_str(&format!("# Pipeline Validation Report\n\n"));
+        report.push_str("# Pipeline Validation Report\n\n");
         report.push_str(&format!("{}\n\n", self.summary));
         report.push_str(&format!(
             "**Total Checks**: {}/{} passed\n\n",
@@ -613,7 +613,7 @@ impl PipelineValidationReport {
                 for warning in &phase.warnings {
                     report.push_str(&format!("⚠️  {}\n", warning));
                 }
-                report.push_str("\n");
+                report.push('\n');
             }
 
             // Metrics
@@ -622,7 +622,7 @@ impl PipelineValidationReport {
                 for (key, value) in &phase.metrics {
                     report.push_str(&format!("- {}: {:.2}\n", key, value));
                 }
-                report.push_str("\n");
+                report.push('\n');
             }
 
             report.push_str("---\n\n");

--- a/graphrag-core/src/graph/analytics.rs
+++ b/graphrag-core/src/graph/analytics.rs
@@ -541,6 +541,6 @@ mod tests {
         let graph = create_test_graph();
         let coeff = graph.clustering_coefficient();
 
-        assert!(coeff >= 0.0 && coeff <= 1.0);
+        assert!((0.0..=1.0).contains(&coeff));
     }
 }

--- a/graphrag-core/src/graph/embeddings.rs
+++ b/graphrag-core/src/graph/embeddings.rs
@@ -598,7 +598,7 @@ mod tests {
         assert_eq!(walks.len(), 5); // 5 nodes * 1 walk per node
         for walk in &walks {
             assert!(walk.len() <= 5);
-            assert!(walk.len() > 0);
+            assert!(!walk.is_empty());
         }
     }
 }

--- a/graphrag-core/src/graph/incremental.rs
+++ b/graphrag-core/src/graph/incremental.rs
@@ -158,6 +158,7 @@ pub enum Operation {
 
 /// Data associated with a change
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum ChangeData {
     /// Entity data
     Entity(Entity),

--- a/graphrag-core/src/graph/leiden.rs
+++ b/graphrag-core/src/graph/leiden.rs
@@ -155,7 +155,7 @@ impl HierarchicalCommunities {
         for meta in &metadata {
             by_type
                 .entry(meta.entity_type.clone())
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(meta);
         }
 
@@ -508,6 +508,7 @@ impl LeidenCommunityDetector {
     }
 
     /// Hierarchical Leiden algorithm implementation
+    #[allow(clippy::type_complexity)]
     fn hierarchical_leiden(
         &self,
         graph: &Graph<String, f32, Undirected>,
@@ -736,12 +737,10 @@ impl LeidenCommunityDetector {
         let sigma_tot_from = self.total_degree_of_community(graph, from_community, communities);
 
         // Delta Q using Newman's modularity formula
-        let delta = ((k_i_in_to as f32 - k_i_in_from as f32) / total_edges)
+        ((k_i_in_to as f32 - k_i_in_from as f32) / total_edges)
             - self.config.resolution
                 * degree
-                * ((sigma_tot_to - sigma_tot_from + degree) / (total_edges * total_edges));
-
-        delta
+                * ((sigma_tot_to - sigma_tot_from + degree) / (total_edges * total_edges))
     }
 
     /// Count edges from node to a specific community

--- a/graphrag-core/src/graph/traversal.rs
+++ b/graphrag-core/src/graph/traversal.rs
@@ -60,15 +60,16 @@ pub struct GraphTraversal {
     config: TraversalConfig,
 }
 
+impl Default for GraphTraversal {
+    fn default() -> Self {
+        Self::new(TraversalConfig::default())
+    }
+}
+
 impl GraphTraversal {
     /// Create a new graph traversal system
     pub fn new(config: TraversalConfig) -> Self {
         Self { config }
-    }
-
-    /// Create with default configuration
-    pub fn default() -> Self {
-        Self::new(TraversalConfig::default())
     }
 
     /// Breadth-First Search (BFS) from a source entity
@@ -172,6 +173,7 @@ impl GraphTraversal {
     }
 
     /// Recursive DFS helper
+    #[allow(clippy::too_many_arguments)]
     fn dfs_recursive(
         &self,
         graph: &KnowledgeGraph,
@@ -419,6 +421,7 @@ impl GraphTraversal {
     }
 
     /// Recursive helper for find_all_paths
+    #[allow(clippy::too_many_arguments)]
     fn find_paths_recursive(
         &self,
         graph: &KnowledgeGraph,
@@ -597,10 +600,10 @@ mod tests {
             0.9,
         );
 
-        graph.add_entity(entity_a);
-        graph.add_entity(entity_b);
-        graph.add_entity(entity_c);
-        graph.add_entity(entity_d);
+        graph.add_entity(entity_a).unwrap();
+        graph.add_entity(entity_b).unwrap();
+        graph.add_entity(entity_c).unwrap();
+        graph.add_entity(entity_d).unwrap();
 
         // Add relationships
         let _ = graph.add_relationship(Relationship {

--- a/graphrag-core/src/graph/traversal.rs
+++ b/graphrag-core/src/graph/traversal.rs
@@ -639,7 +639,7 @@ mod tests {
         let result = traversal.bfs(&graph, &source).unwrap();
 
         // Should discover all connected entities
-        assert!(result.entities.len() >= 1);
+        assert!(!result.entities.is_empty());
         assert!(result.distances.contains_key(&source));
     }
 
@@ -652,7 +652,7 @@ mod tests {
         let result = traversal.dfs(&graph, &source).unwrap();
 
         // Should discover entities through DFS
-        assert!(result.entities.len() >= 1);
+        assert!(!result.entities.is_empty());
         assert!(result.distances.contains_key(&source));
     }
 

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -858,21 +858,15 @@ impl GraphRAG {
         // Use a simple approach: repeatedly remove until no more found
         let mut result = text.to_string();
 
-        loop {
-            // Find opening tag
-            if let Some(start) = result.find("<think>") {
-                // Find corresponding closing tag
-                if let Some(end) = result[start..].find("</think>") {
-                    // Remove the entire block
-                    let end_pos = start + end + "</think>".len();
-                    result.replace_range(start..end_pos, "");
-                } else {
-                    // No closing tag found, just remove opening tag
-                    result.replace_range(start..start + "<think>".len(), "");
-                    break;
-                }
+        while let Some(start) = result.find("<think>") {
+            // Find corresponding closing tag
+            if let Some(end) = result[start..].find("</think>") {
+                // Remove the entire block
+                let end_pos = start + end + "</think>".len();
+                result.replace_range(start..end_pos, "");
             } else {
-                // No more opening tags
+                // No closing tag found, just remove opening tag
+                result.replace_range(start..start + "<think>".len(), "");
                 break;
             }
         }

--- a/graphrag-core/src/lightrag/graph_indexer.rs
+++ b/graphrag-core/src/lightrag/graph_indexer.rs
@@ -73,7 +73,7 @@ impl GraphIndexer {
             // Look for capitalized phrases
             if window
                 .iter()
-                .all(|w| w.chars().next().map_or(false, |c| c.is_uppercase()))
+                .all(|w| w.chars().next().is_some_and(|c| c.is_uppercase()))
             {
                 entities.push(ExtractedEntity {
                     id: format!("entity_{}", entity_id),
@@ -87,7 +87,7 @@ impl GraphIndexer {
 
         // Single capitalized words
         for word in words {
-            if word.len() > 2 && word.chars().next().map_or(false, |c| c.is_uppercase()) {
+            if word.len() > 2 && word.chars().next().is_some_and(|c| c.is_uppercase()) {
                 entities.push(ExtractedEntity {
                     id: format!("entity_{}", entity_id),
                     name: word.to_string(),

--- a/graphrag-core/src/nlp/custom_ner.rs
+++ b/graphrag-core/src/nlp/custom_ner.rs
@@ -136,7 +136,7 @@ impl CustomNER {
         }
 
         self.rules.push(rule);
-        self.rules.sort_by(|a, b| b.priority.cmp(&a.priority));
+        self.rules.sort_by_key(|r| std::cmp::Reverse(r.priority));
     }
 
     /// Extract entities from text

--- a/graphrag-core/src/nlp/syntax_analyzer.rs
+++ b/graphrag-core/src/nlp/syntax_analyzer.rs
@@ -365,9 +365,9 @@ impl SyntaxAnalyzer {
             .unwrap_or(0);
 
         // Find subject (noun/pronoun before verb)
-        for i in 0..root_idx {
+        for (i, token) in tokens.iter().enumerate().take(root_idx) {
             if matches!(
-                tokens[i].pos,
+                token.pos,
                 POSTag::Noun | POSTag::ProperNoun | POSTag::Pronoun
             ) {
                 dependencies.push(Dependency {
@@ -380,8 +380,8 @@ impl SyntaxAnalyzer {
         }
 
         // Find object (noun after verb)
-        for i in (root_idx + 1)..tokens.len() {
-            if matches!(tokens[i].pos, POSTag::Noun | POSTag::ProperNoun) {
+        for (i, token) in tokens.iter().enumerate().skip(root_idx + 1) {
+            if matches!(token.pos, POSTag::Noun | POSTag::ProperNoun) {
                 dependencies.push(Dependency {
                     head: root_idx,
                     dependent: i,

--- a/graphrag-core/src/ollama/mod.rs
+++ b/graphrag-core/src/ollama/mod.rs
@@ -197,10 +197,7 @@ impl AsyncLanguageModel for AsyncOllamaGenerator {
                 "{}:{}/api/version",
                 self.client.config.host, self.client.config.port
             );
-            match self.client.client.get(&endpoint).call() {
-                Ok(_) => true,
-                Err(_) => false,
-            }
+            self.client.client.get(&endpoint).call().is_ok()
         }
         #[cfg(not(feature = "ureq"))]
         {

--- a/graphrag-core/src/persistence/workspace.rs
+++ b/graphrag-core/src/persistence/workspace.rs
@@ -189,7 +189,7 @@ impl WorkspaceManager {
         }
 
         // Sort by modification time (newest first)
-        workspaces.sort_by(|a, b| b.metadata.modified_at.cmp(&a.metadata.modified_at));
+        workspaces.sort_by_key(|w| std::cmp::Reverse(w.metadata.modified_at));
 
         Ok(workspaces)
     }

--- a/graphrag-core/src/pipeline/builder.rs
+++ b/graphrag-core/src/pipeline/builder.rs
@@ -235,7 +235,7 @@ impl PipelineBuilder {
                 serde_json::Value::Object(sorted)
             },
             serde_json::Value::Array(arr) => {
-                serde_json::Value::Array(arr.iter().map(|v| Self::canonicalize_json(v)).collect())
+                serde_json::Value::Array(arr.iter().map(Self::canonicalize_json).collect())
             },
             other => other.clone(),
         }

--- a/graphrag-core/src/pipeline/cached_stage.rs
+++ b/graphrag-core/src/pipeline/cached_stage.rs
@@ -49,7 +49,7 @@ where
     ///
     /// `max_capacity` controls maximum number of cached entries.
     /// `ttl` is the time-to-live for each cache entry.
-    pub fn new(inner: Arc<dyn Stage<I, O>>, max_capacity: u64, ttl: Duration) -> Self {
+    pub fn new(inner: Arc<dyn Stage<I, O>>, _max_capacity: u64, ttl: Duration) -> Self {
         Self {
             inner,
             #[cfg(feature = "caching")]
@@ -70,7 +70,7 @@ where
     /// Results are written to both L1 and L2.
     pub fn with_dual_mode_cache(
         inner: Arc<dyn Stage<I, O>>,
-        max_capacity: u64,
+        _max_capacity: u64,
         ttl: Duration,
         l2: Arc<DualModeCache>,
     ) -> Self {

--- a/graphrag-core/src/pipeline/cached_stage.rs
+++ b/graphrag-core/src/pipeline/cached_stage.rs
@@ -49,7 +49,8 @@ where
     ///
     /// `max_capacity` controls maximum number of cached entries.
     /// `ttl` is the time-to-live for each cache entry.
-    pub fn new(inner: Arc<dyn Stage<I, O>>, _max_capacity: u64, ttl: Duration) -> Self {
+    #[cfg_attr(not(feature = "caching"), allow(unused_variables))]
+    pub fn new(inner: Arc<dyn Stage<I, O>>, max_capacity: u64, ttl: Duration) -> Self {
         Self {
             inner,
             #[cfg(feature = "caching")]
@@ -68,9 +69,10 @@ where
     ///
     /// When moka (L1) misses, the L2 cache is checked before running the inner stage.
     /// Results are written to both L1 and L2.
+    #[cfg_attr(not(feature = "caching"), allow(unused_variables))]
     pub fn with_dual_mode_cache(
         inner: Arc<dyn Stage<I, O>>,
-        _max_capacity: u64,
+        max_capacity: u64,
         ttl: Duration,
         l2: Arc<DualModeCache>,
     ) -> Self {

--- a/graphrag-core/src/pipeline/cached_stage.rs
+++ b/graphrag-core/src/pipeline/cached_stage.rs
@@ -49,6 +49,10 @@ where
     ///
     /// `max_capacity` controls maximum number of cached entries.
     /// `ttl` is the time-to-live for each cache entry.
+    // `max_capacity` is only read under `#[cfg(feature = "caching")]`. Do NOT prefix with
+    // `_` — a previous `clippy --fix` did that and silently broke compilation when the
+    // `caching` feature was enabled. The cfg_attr keeps the unused-var lint quiet when
+    // the feature is off, without touching the parameter name.
     #[cfg_attr(not(feature = "caching"), allow(unused_variables))]
     pub fn new(inner: Arc<dyn Stage<I, O>>, max_capacity: u64, ttl: Duration) -> Self {
         Self {
@@ -69,6 +73,7 @@ where
     ///
     /// When moka (L1) misses, the L2 cache is checked before running the inner stage.
     /// Results are written to both L1 and L2.
+    // See `new()` above re: `max_capacity` naming under feature flags.
     #[cfg_attr(not(feature = "caching"), allow(unused_variables))]
     pub fn with_dual_mode_cache(
         inner: Arc<dyn Stage<I, O>>,

--- a/graphrag-core/src/pipeline/dual_mode_cache.rs
+++ b/graphrag-core/src/pipeline/dual_mode_cache.rs
@@ -2,7 +2,9 @@
 //!
 //! Enables seamless switching between in-memory (fast) and disk-based (persistent) caching.
 
-use super::persistent_cache::{CacheStats, PersistentCacheBackend};
+use super::persistent_cache::CacheStats;
+#[cfg(feature = "persistent-cache")]
+use super::persistent_cache::PersistentCacheBackend;
 use std::collections::HashMap;
 use std::sync::Mutex;
 

--- a/graphrag-core/src/pipeline/registry.rs
+++ b/graphrag-core/src/pipeline/registry.rs
@@ -5,11 +5,14 @@ use std::collections::HashMap;
 /// Identifies a stage by name and version.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StageId {
+    /// Stage name (unique within a version).
     pub name: String,
+    /// Stage version string.
     pub version: String,
 }
 
 impl StageId {
+    /// Construct a `StageId` from name and version.
     pub fn new(name: impl Into<String>, version: impl Into<String>) -> Self {
         Self {
             name: name.into(),

--- a/graphrag-core/src/pipeline/stage.rs
+++ b/graphrag-core/src/pipeline/stage.rs
@@ -10,8 +10,11 @@ use std::fmt;
 /// Error type for stage execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StageError {
+    /// Name of the stage that produced the error.
     pub stage_name: String,
+    /// Short human-readable error message.
     pub message: String,
+    /// Optional additional context describing the error.
     pub details: Option<String>,
 }
 

--- a/graphrag-core/src/query/adaptive_routing.rs
+++ b/graphrag-core/src/query/adaptive_routing.rs
@@ -61,7 +61,7 @@ pub enum QueryComplexity {
 
 impl QueryComplexity {
     /// Convert complexity to hierarchical level
-    pub fn to_level(&self, max_level: usize) -> usize {
+    pub fn to_level(self, max_level: usize) -> usize {
         match self {
             QueryComplexity::VeryBroad => max_level.max(2),
             QueryComplexity::Broad => (max_level - 1).max(1),

--- a/graphrag-core/src/reranking/cross_encoder.rs
+++ b/graphrag-core/src/reranking/cross_encoder.rs
@@ -341,7 +341,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(score >= 0.0 && score <= 1.0);
+        assert!((0.0..=1.0).contains(&score));
     }
 
     #[test]

--- a/graphrag-core/src/retrieval/enriched.rs
+++ b/graphrag-core/src/retrieval/enriched.rs
@@ -353,7 +353,7 @@ impl EnrichedRetriever {
 
         // Also check for direct mentions like "Introduction", "Conclusion"
         for word in query_lower.split_whitespace() {
-            if word.chars().next().map_or(false, |c| c.is_uppercase()) && word.len() > 5 {
+            if word.chars().next().is_some_and(|c| c.is_uppercase()) && word.len() > 5 {
                 refs.push(word.to_string());
             }
         }

--- a/graphrag-core/src/retrieval/explain.rs
+++ b/graphrag-core/src/retrieval/explain.rs
@@ -150,11 +150,11 @@ impl TracingRetriever {
             duration: search_duration / 3,
             candidates_produced: results.len(),
             score_breakdown: results.first().map(|top| ScoreBreakdown {
-                    vector_score: top.semantic_score,
-                    graph_score: 0.0,
-                    keyword_score: top.keyword_score,
-                    final_score: top.score,
-                }),
+                vector_score: top.semantic_score,
+                graph_score: 0.0,
+                keyword_score: top.keyword_score,
+                final_score: top.score,
+            }),
         });
 
         let total_duration = total_start.elapsed();

--- a/graphrag-core/src/retrieval/explain.rs
+++ b/graphrag-core/src/retrieval/explain.rs
@@ -149,16 +149,12 @@ impl TracingRetriever {
             stage_name: "fusion".to_string(),
             duration: search_duration / 3,
             candidates_produced: results.len(),
-            score_breakdown: if let Some(top) = results.first() {
-                Some(ScoreBreakdown {
+            score_breakdown: results.first().map(|top| ScoreBreakdown {
                     vector_score: top.semantic_score,
                     graph_score: 0.0,
                     keyword_score: top.keyword_score,
                     final_score: top.score,
-                })
-            } else {
-                None
-            },
+                }),
         });
 
         let total_duration = total_start.elapsed();

--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -1102,18 +1102,15 @@ impl RetrievalSystem {
         // Apply query-specific score adjustments
         for result in &mut results {
             match analysis.query_type {
-                QueryType::EntityFocused
-                    if result.result_type == ResultType::Entity => {
-                        result.score *= 1.2;
-                    },
-                QueryType::Conceptual
-                    if result.result_type == ResultType::HierarchicalSummary => {
-                        result.score *= 1.1;
-                    },
-                QueryType::Relationship
-                    if result.entities.len() > 1 => {
-                        result.score *= 1.15;
-                    },
+                QueryType::EntityFocused if result.result_type == ResultType::Entity => {
+                    result.score *= 1.2;
+                },
+                QueryType::Conceptual if result.result_type == ResultType::HierarchicalSummary => {
+                    result.score *= 1.1;
+                },
+                QueryType::Relationship if result.entities.len() > 1 => {
+                    result.score *= 1.15;
+                },
                 _ => {},
             }
 

--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -1102,21 +1102,18 @@ impl RetrievalSystem {
         // Apply query-specific score adjustments
         for result in &mut results {
             match analysis.query_type {
-                QueryType::EntityFocused => {
-                    if result.result_type == ResultType::Entity {
+                QueryType::EntityFocused
+                    if result.result_type == ResultType::Entity => {
                         result.score *= 1.2;
-                    }
-                },
-                QueryType::Conceptual => {
-                    if result.result_type == ResultType::HierarchicalSummary {
+                    },
+                QueryType::Conceptual
+                    if result.result_type == ResultType::HierarchicalSummary => {
                         result.score *= 1.1;
-                    }
-                },
-                QueryType::Relationship => {
-                    if result.entities.len() > 1 {
+                    },
+                QueryType::Relationship
+                    if result.entities.len() > 1 => {
                         result.score *= 1.15;
-                    }
-                },
+                    },
                 _ => {},
             }
 

--- a/graphrag-core/src/rograg/fuzzy_matcher.rs
+++ b/graphrag-core/src/rograg/fuzzy_matcher.rs
@@ -604,11 +604,11 @@ impl FuzzyMatcher {
 
         let mut matrix = vec![vec![0; len2 + 1]; len1 + 1];
 
-        for (i, item) in matrix.iter_mut().enumerate().take(len1 + 1) {
-            item[0] = i;
+        for (i, row) in matrix.iter_mut().enumerate() {
+            row[0] = i;
         }
-        for j in 0..=len2 {
-            matrix[0][j] = j;
+        for (j, cell) in matrix[0].iter_mut().enumerate() {
+            *cell = j;
         }
 
         for i in 1..=len1 {

--- a/graphrag-core/src/summarization/mod.rs
+++ b/graphrag-core/src/summarization/mod.rs
@@ -567,7 +567,7 @@ impl DocumentTree {
             .level_configs
             .get(&level)
             .cloned()
-            .unwrap_or_else(|| {
+            .unwrap_or({
                 // Default configuration based on level
                 LevelConfig {
                     max_length: self.config.max_summary_length,
@@ -596,7 +596,7 @@ impl DocumentTree {
 
         let mut result = String::new();
         for sentence in sentences {
-            if result.len() + sentence.len() + 1 <= max_length - 3 {
+            if result.len() + sentence.len() < max_length - 3 {
                 if !result.is_empty() {
                     result.push('.');
                 }

--- a/graphrag-core/src/text/chunking.rs
+++ b/graphrag-core/src/text/chunking.rs
@@ -280,7 +280,7 @@ mod tests {
         // The second paragraph is long enough (128 chars) and will be chunked
 
         // Verify that we got meaningful chunks from the second paragraph
-        assert!(chunks.len() >= 1, "Should have at least one chunk");
+        assert!(!chunks.is_empty(), "Should have at least one chunk");
 
         // First chunk should start from second paragraph
         assert!(

--- a/graphrag-core/src/text/extractive_summarizer.rs
+++ b/graphrag-core/src/text/extractive_summarizer.rs
@@ -207,7 +207,7 @@ impl ExtractiveSummarizer {
             .iter()
             .filter(|word| {
                 // Check if word starts with uppercase and is not sentence start
-                word.chars().next().map_or(false, |c| c.is_uppercase())
+                word.chars().next().is_some_and(|c| c.is_uppercase())
                     && word.len() > 2
                     && !self.stopwords.contains(&word.to_lowercase())
             })
@@ -253,7 +253,7 @@ impl ExtractiveSummarizer {
             let sentence_len = sentences[idx].len();
 
             // Check if adding this sentence would exceed limit
-            if current_length + sentence_len + 1 <= max_length {
+            if current_length + sentence_len < max_length {
                 // +1 for space
                 selected_indices.push(idx);
                 current_length += sentence_len + 1;
@@ -295,7 +295,7 @@ impl ExtractiveSummarizer {
             && !sentence
                 .chars()
                 .nth(end)
-                .map_or(false, |c| c.is_whitespace())
+                .is_some_and(|c| c.is_whitespace())
         {
             end -= 1;
         }

--- a/graphrag-core/src/text/extractive_summarizer.rs
+++ b/graphrag-core/src/text/extractive_summarizer.rs
@@ -254,8 +254,8 @@ impl ExtractiveSummarizer {
 
             // Check if adding this sentence would exceed limit
             if current_length + sentence_len < max_length {
-                // +1 for space
                 selected_indices.push(idx);
+                // +1 accounts for the joining space
                 current_length += sentence_len + 1;
             }
 

--- a/graphrag-core/src/text/extractive_summarizer.rs
+++ b/graphrag-core/src/text/extractive_summarizer.rs
@@ -291,12 +291,7 @@ impl ExtractiveSummarizer {
             end -= 1;
         }
 
-        while end > 0
-            && !sentence
-                .chars()
-                .nth(end)
-                .is_some_and(|c| c.is_whitespace())
-        {
+        while end > 0 && !sentence.chars().nth(end).is_some_and(|c| c.is_whitespace()) {
             end -= 1;
         }
 

--- a/graphrag-core/src/text/mod.rs
+++ b/graphrag-core/src/text/mod.rs
@@ -476,7 +476,7 @@ impl TextProcessor {
         }
 
         let mut sorted_words: Vec<_> = word_counts.into_iter().collect();
-        sorted_words.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted_words.sort_by_key(|w| std::cmp::Reverse(w.1));
 
         sorted_words
             .into_iter()

--- a/graphrag-core/tests/code_agent_tests.rs
+++ b/graphrag-core/tests/code_agent_tests.rs
@@ -241,7 +241,10 @@ mod code_retrieval {
             .expect("Failed to build graph");
 
         let results: Vec<_> = graph.entities().collect();
-        assert!(!results.is_empty(), "Should expand queries across documents");
+        assert!(
+            !results.is_empty(),
+            "Should expand queries across documents"
+        );
     }
 
     #[test]
@@ -751,7 +754,8 @@ mod e2e_agent_workflows {
 
         // Generate suggestion based on retrieved context
         let suggestion = "Based on existing structure, suggested implementation: \
-             impl Calculator { pub fn multiply(&self, a: i32, b: i32) -> i32 { a * b } }".to_string();
+             impl Calculator { pub fn multiply(&self, a: i32, b: i32) -> i32 { a * b } }"
+            .to_string();
 
         assert!(
             !suggestion.is_empty(),

--- a/graphrag-core/tests/code_agent_tests.rs
+++ b/graphrag-core/tests/code_agent_tests.rs
@@ -385,6 +385,7 @@ mod performance_baselines {
     /// Override via env vars: OXIDIZED_INDEXING_THRESHOLD_MS, etc.
     const DEFAULT_INDEXING_THRESHOLD_MS: u128 = 5000;
     const DEFAULT_QUERY_THRESHOLD_MS: u128 = 1000;
+    #[allow(dead_code)]
     const DEFAULT_CHUNKING_THRESHOLD_MS: u128 = 2000;
 
     #[test]

--- a/graphrag-core/tests/code_agent_tests.rs
+++ b/graphrag-core/tests/code_agent_tests.rs
@@ -241,7 +241,7 @@ mod code_retrieval {
             .expect("Failed to build graph");
 
         let results: Vec<_> = graph.entities().collect();
-        assert!(results.len() > 0, "Should expand queries across documents");
+        assert!(!results.is_empty(), "Should expand queries across documents");
     }
 
     #[test]
@@ -749,10 +749,8 @@ mod e2e_agent_workflows {
             .collect();
 
         // Generate suggestion based on retrieved context
-        let suggestion = format!(
-            "Based on existing structure, suggested implementation: \
-             impl Calculator {{ pub fn multiply(&self, a: i32, b: i32) -> i32 {{ a * b }} }}"
-        );
+        let suggestion = "Based on existing structure, suggested implementation: \
+             impl Calculator { pub fn multiply(&self, a: i32, b: i32) -> i32 { a * b } }".to_string();
 
         assert!(
             !suggestion.is_empty(),

--- a/graphrag-core/tests/common.rs
+++ b/graphrag-core/tests/common.rs
@@ -22,6 +22,7 @@ pub fn fixture_document(filename: &str) -> Document {
 }
 
 /// Index fixture files into a GraphRAG knowledge graph
+#[allow(dead_code)]
 pub fn index_fixtures(filenames: &[&str], chunk_size: usize) -> Result<KnowledgeGraph> {
     let mut graph = KnowledgeGraph::new();
     let processor = TextProcessor::new(chunk_size, chunk_size / 5)?;

--- a/graphrag-core/tests/incremental_correctness_test.rs
+++ b/graphrag-core/tests/incremental_correctness_test.rs
@@ -4,6 +4,8 @@
 //! to graphs built from scratch, and that delete/rollback operations
 //! maintain consistency.
 
+#![cfg(feature = "incremental")]
+
 use graphrag_core::core::{Entity, EntityId, KnowledgeGraph, Relationship};
 use graphrag_core::graph::incremental::{
     ChangeData, ChangeRecord, ChangeType, ConflictResolver, ConflictStrategy, DeltaStatus,
@@ -225,7 +227,7 @@ async fn test_consistency_report_detects_issues() {
 
     assert!(report.orphaned_entities.len() >= 2, "Should detect orphans");
     assert!(
-        report.missing_embeddings.len() >= 1,
+        !report.missing_embeddings.is_empty(),
         "Should detect missing embedding"
     );
 }
@@ -254,7 +256,7 @@ async fn test_batch_upsert_entities() {
     let graph = KnowledgeGraph::new();
     let mut store = ProductionGraphStore::new(graph, config, resolver);
 
-    let entities: Vec<Entity> = (0..50).map(|i| create_test_entity(i)).collect();
+    let entities: Vec<Entity> = (0..50).map(create_test_entity).collect();
     let ids = store
         .batch_upsert_entities(entities, ConflictStrategy::KeepNew)
         .await

--- a/graphrag-core/tests/incremental_perf_test.rs
+++ b/graphrag-core/tests/incremental_perf_test.rs
@@ -2,6 +2,8 @@
 //!
 //! Validates that incremental updates cost <5% of a full rebuild.
 
+#![cfg(feature = "incremental")]
+
 use graphrag_core::core::{Entity, EntityId, KnowledgeGraph, Relationship};
 use graphrag_core::graph::incremental::{
     ConflictResolver, ConflictStrategy, IncrementalConfig, IncrementalGraphStore,
@@ -203,7 +205,7 @@ async fn test_batch_upsert_performance() {
 
     // Measure batch upsert
     let batch: Vec<Entity> = (base_count..(base_count + batch_size))
-        .map(|i| create_test_entity(i))
+        .map(create_test_entity)
         .collect();
 
     let start = Instant::now();

--- a/graphrag-core/tests/text_pipeline_fixtures.rs
+++ b/graphrag-core/tests/text_pipeline_fixtures.rs
@@ -378,7 +378,7 @@ fn test_edge_cases_with_fixtures() {
         .chunk_and_enrich(&document)
         .expect("Should handle minimal document");
 
-    assert!(chunks.len() >= 1, "Should create at least one chunk");
+    assert!(!chunks.is_empty(), "Should create at least one chunk");
     assert!(
         chunks[0].metadata.chapter.is_some(),
         "Should detect title heading"


### PR DESCRIPTION
## Summary

Makes `cargo clippy -p graphrag-core --all-targets -- -D warnings` clean (was 65 errors).

This is one step toward unblocking PR #162 (release: develop → main), whose `nix-check` is failing because the workflow runs `cargo clippy --all-targets -- -D warnings` workspace-wide.

## What's fixed

In `graphrag-core` only:

- **Auto-fixed by `cargo clippy --fix`** across 21 files (~31 errors): redundant closures, derivable `Default`, `RangeInclusive::contains`, `map_or` simplification, redundant pattern matching, `length_comparison_to_zero`, etc.
- **6 missing-docs** comments added in `pipeline/registry.rs` and `pipeline/stage.rs`
- **5 `sort_by(|a,b| b.X.cmp(&a.X))` → `sort_by_key(|x| Reverse(x.X))`** conversions
- **4 disallowed `data` placeholder names** → `record`
- **4 `needless_range_loop`** rewrites (matrix init in Levenshtein / fuzzy matcher / token scans)
- **2 `#[allow(clippy::too_many_arguments)]`** on internal recursive helpers (`dfs_recursive`, `find_paths_recursive`)
- **1 `#[allow(clippy::large_enum_variant)]`** on `ChangeData` (boxing would break the many `ChangeData::Entity(entity)` call sites — out of scope)
- `while let` conversion, `Default` impl for `GraphTraversal`, `to_level: &self → self`, field-assignment-in-init, etc.
- **Pre-existing surface issues:** 2 `///!` → `//!` in examples (malformed doc syntax), 3 `#[allow(dead_code)]` on feature-conditional unused items, `#![cfg(feature = "incremental")]` gate on 2 test files whose imports require the feature
- `cached_stage::{new, with_dual_mode_cache}`: revert clippy --fix's mis-prefixing of `max_capacity` (the param is used under `#[cfg(feature = "caching")]`)

## Out of scope (file follow-ups)

`cargo clippy --workspace --all-targets -- -D warnings` still has **~42 pre-existing errors** in:
- `graphrag-cli` — redundant import, `if let` on `is_some()` checked variant, `sort_by` reverse
- `graphrag-server` — manual suffix-strip, `redundant_closure`, others
- `graphrag-wasm` — ~10 lint families (acronym casing, doc-comment style, `or_insert_with(Vec::new)`, useless `format!`, etc.) plus duplicated attributes in tests/examples
- `graphrag-aivcs` — half-finished `RagRunRecorder` migration: there are TWO structs with the same name (`run_recorder::RagRunRecorder` sync API used by 2 examples, `recorder::RagRunRecorder` async ledger-aware API used by `tests/integration.rs`). `lib.rs` re-exports the sync one; the integration test won't compile. Resolving requires picking a winner and updating the loser's call sites — design decision, not a clippy fix.

These existed on `develop` before this PR. **`nix-check` on PR #162 will keep failing until separate per-crate PRs land for each of the above.**

## Test plan

- [ ] `cargo clippy -p graphrag-core --all-targets -- -D warnings` passes locally (verified)
- [ ] `cargo build -p graphrag-core` passes locally (verified)
- [ ] CI `nix-check` will still fail on this PR alone (expected — workspace cleanup needed). Run it anyway to confirm only the expected non-`graphrag-core` failures remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)