### PR TITLE
fix(aivcs): integration tests import ledger-aware RagRunRecorder (re-enable cfg(any()) gate)

### DIFF
--- a/graphrag-aivcs/tests/integration.rs
+++ b/graphrag-aivcs/tests/integration.rs
@@ -1,17 +1,21 @@
 //! Integration tests for graphrag-aivcs using MemoryRunLedger.
 //!
-//! NOTE: These tests reference a `RagRunRecorder::start(ledger, &spec)` async
-//! API that does not exist on the current `RagRunRecorder` (which only has
-//! `::new(query)` sync). They were either landed alongside an aspirational
-//! API or written for a future redesign. Gated out with `cfg(any())` until
-//! the recorder either grows the `start`/`finish_ok`/etc. ledger-aware API
-//! the tests want, or these tests are rewritten against the existing API.
-//! See follow-up issue tracking this divergence.
-#![cfg(any())]
+//! Two `RagRunRecorder` types live in this crate:
+//!   - `run_recorder::RagRunRecorder` (sync, `::new(query)`, no ledger) — the
+//!     legacy one currently re-exported from `lib.rs` and used by the
+//!     `aivcs_adapter` + the examples.
+//!   - `recorder::RagRunRecorder` (async, `::start(ledger, &spec)`, ledger-
+//!     aware via `aivcs_core::GraphRunRecorder`) — the type this test suite
+//!     was written against.
+//!
+//! Until the duplication is consolidated, we import the ledger-aware one
+//! directly from its submodule rather than via the crate root. See
+//! stevedores-org/oxidizedRAG#178 for the follow-up.
 
 use std::sync::Arc;
 
-use graphrag_aivcs::{GraphRagSpec, RagAdapter, RagRunRecorder};
+use graphrag_aivcs::recorder::RagRunRecorder;
+use graphrag_aivcs::{GraphRagSpec, RagAdapter};
 use oxidized_state::{fakes::MemoryRunLedger, RunLedger, RunStatus};
 
 fn test_spec() -> GraphRagSpec {


### PR DESCRIPTION
## Summary

The `graphrag-aivcs` crate has **two** `RagRunRecorder` types:

- `run_recorder::RagRunRecorder` — sync, `::new(query)`, no ledger. Re-exported as `graphrag_aivcs::RagRunRecorder` today; used by `aivcs_adapter` and the examples.
- `recorder::RagRunRecorder` — async, `::start(ledger, &spec)`, ledger-aware via `aivcs_core::GraphRunRecorder`. What `tests/integration.rs` was written against.

PR #175 had to gate `tests/integration.rs` out with `#![cfg(any())]` because clippy couldn't resolve `RagRunRecorder::start` on the re-exported legacy type. This PR removes that gate and lets the tests import the ledger-aware one directly from its submodule:

```diff
-use graphrag_aivcs::{GraphRagSpec, RagAdapter, RagRunRecorder};
+use graphrag_aivcs::recorder::RagRunRecorder;
+use graphrag_aivcs::{GraphRagSpec, RagAdapter};
```

Both types stay in place; the public re-export is unchanged so the examples and `aivcs_adapter` keep working.

## Why this approach over swapping the re-export

Flipping `pub use run_recorder::RagRunRecorder` → `pub use recorder::RagRunRecorder` would break:
- `graphrag-aivcs/examples/integration_demo.rs:16`
- `graphrag-aivcs/examples/persistence_architecture.rs:32`
- `graphrag-aivcs/src/aivcs_adapter.rs:69,81,92`
- `graphrag-aivcs/src/persistence.rs:29` (doctest)
- `graphrag-aivcs/src/aivcs_adapter.rs:17` (doctest)

All depend on the sync `::new(query)` contract. Consolidating the two `RagRunRecorder` types into a single canonical API is the larger follow-up tracked in #178 — out of scope here.

## Verification

```
cargo test -p graphrag-aivcs --test integration
running 8 tests
test spec_digest_changes_on_mutation ... ok
test spec_digest_is_deterministic ... ok
test recorder_start_creates_run ... ok
test finish_ok_sets_completed_status ... ok
test finish_err_sets_failed_status ... ok
test llm_event_is_persisted ... ok
test retrieval_event_is_persisted ... ok
test adapter_in_memory_works_end_to_end ... ok

test result: ok. 8 passed; 0 failed.
```

`cargo clippy --workspace --all-targets --no-deps -- -D warnings` and `cargo fmt --check` remain clean.

## Base / dependency

Based on `chore/graphrag-core-clippy-cleanup` (the head of #175) because the `#![cfg(any())]` gate this PR removes was introduced there. Once #175 merges, retarget to `develop`.

## Test plan

- [x] `cargo test -p graphrag-aivcs --test integration` — 8 passed locally
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI nix-check passes

Refs #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)