### PR TITLE
fix(docs): clear 9 rustdoc errors blocking nix flake check on develop

### DIFF
--- a/graphrag-cli/src/commands/mod.rs
+++ b/graphrag-cli/src/commands/mod.rs
@@ -1,11 +1,11 @@
 //! Slash command system for the TUI
 //!
 //! Provides parsing and execution of slash commands like:
-//! - /config <file>
-//! - /load <file>
-//! - /stats
-//! - /entities [filter]
-//! - /workspace <name>
+//! - `/config <file>`
+//! - `/load <file>`
+//! - `/stats`
+//! - `/entities [filter]`
+//! - `/workspace <name>`
 
 use color_eyre::eyre::{eyre, Result};
 use std::path::PathBuf;

--- a/graphrag-core/src/core/traits.rs
+++ b/graphrag-core/src/core/traits.rs
@@ -1403,7 +1403,7 @@ pub mod sync_to_async {
         }
     }
 
-    /// Blanket implementation for Box<T> where T implements AsyncLanguageModel
+    /// Blanket implementation for `Box<T>` where `T` implements `AsyncLanguageModel`
     #[async_trait]
     impl<T> AsyncLanguageModel for Box<T>
     where

--- a/graphrag-core/src/lib.rs
+++ b/graphrag-core/src/lib.rs
@@ -343,7 +343,7 @@ impl GraphRAG {
     ///   (regex + capitalization) for fast, resource-efficient processing.
     /// - **Hybrid** (config.approach = "hybrid"): Combines both approaches with weighted fusion.
     ///
-    /// The selection is controlled by `config.approach` and mapped from TomlConfig's [mode] section.
+    /// The selection is controlled by `config.approach` and mapped from TomlConfig's `[mode]` section.
     #[cfg(feature = "async")]
     pub async fn build_graph(&mut self) -> Result<()> {
         use indicatif::{ProgressBar, ProgressStyle};

--- a/graphrag-core/src/retrieval/hipporag_ppr.rs
+++ b/graphrag-core/src/retrieval/hipporag_ppr.rs
@@ -8,7 +8,7 @@
 //! 2. Passage weights from dense retrieval (scaled down)
 //!
 //! Reference: "HippoRAG: Neurobiologically Inspired Long-Term Memory for Large Language Models"
-//! https://arxiv.org/abs/2405.14831
+//! <https://arxiv.org/abs/2405.14831>
 
 use std::collections::HashMap;
 

--- a/graphrag-core/src/rograg/mod.rs
+++ b/graphrag-core/src/rograg/mod.rs
@@ -13,14 +13,14 @@
 //!
 //! # Key Components
 //!
-//! - [`decomposer`] - Query decomposition using semantic/syntactic/hybrid strategies
-//! - [`fuzzy_matcher`] - Semantic similarity matching for entities and content chunks
-//! - [`intent_classifier`] - Query intent detection with refusal capabilities
-//! - [`logic_form`] - Structured query representation and execution
-//! - [`processor`] - Main ROGRAG processing pipeline orchestration
-//! - [`validator`] - Query validation and quality assessment
-//! - [`quality_metrics`] - Performance and quality tracking
-//! - [`streaming`] - Streaming response generation
+//! - `decomposer` - Query decomposition using semantic/syntactic/hybrid strategies
+//! - `fuzzy_matcher` - Semantic similarity matching for entities and content chunks
+//! - `intent_classifier` - Query intent detection with refusal capabilities
+//! - `logic_form` - Structured query representation and execution
+//! - `processor` - Main ROGRAG processing pipeline orchestration
+//! - `validator` - Query validation and quality assessment
+//! - `quality_metrics` - Performance and quality tracking
+//! - `streaming` - Streaming response generation
 //!
 //! # Usage Example
 //!

--- a/graphrag-core/src/storage/mod.rs
+++ b/graphrag-core/src/storage/mod.rs
@@ -6,9 +6,9 @@
 //! ## Backends
 //!
 //! - [`MemoryStorage`] — in-memory storage for development/testing
-//! - [`surrealdb::SurrealDeltaStorage`] — SurrealDB-backed delta persistence
+//! - `surrealdb::SurrealDeltaStorage` — SurrealDB-backed delta persistence
 //!   (requires `surrealdb-storage` feature)
-//! - [`async_bridge::AsyncKnowledgeGraph`] — sync/async bridge for incremental
+//! - `async_bridge::AsyncKnowledgeGraph` — sync/async bridge for incremental
 //!   updates (requires `incremental` feature)
 
 #[cfg(feature = "surrealdb-storage")]

--- a/graphrag-core/src/vector/mod.rs
+++ b/graphrag-core/src/vector/mod.rs
@@ -16,7 +16,7 @@ use instant_distance::{Builder, Point, Search};
 // #[cfg(feature = "wasm")]
 // pub use voy_store::{VoyStore, VoyStoreStatistics};
 
-/// Wrapper for Vec<f32> to implement Point trait for vector operations
+/// Wrapper for `Vec<f32>` to implement Point trait for vector operations
 #[derive(Debug, Clone, PartialEq)]
 pub struct Vector(Vec<f32>);
 

--- a/graphrag-wasm/src/webllm.rs
+++ b/graphrag-wasm/src/webllm.rs
@@ -1,6 +1,6 @@
 //! WebLLM Bindings for GPU-Accelerated LLM
 //!
-//! Provides Rust bindings to WebLLM (https://github.com/mlc-ai/web-llm),
+//! Provides Rust bindings to WebLLM (<https://github.com/mlc-ai/web-llm>),
 //! a production-ready WebGPU-accelerated LLM runtime for browsers.
 //!
 //! ## Performance


### PR DESCRIPTION
## Summary

`develop`'s `nix-check` job has been failing on the `doc` flake check
since shortly after PR #175 merged. Run [26513135868](https://github.com/stevedores-org/oxidizedRAG/actions/runs/26513135868)
is the latest example.

The failures are not clippy — they're `cargo doc --workspace --no-deps`
with `RUSTDOCFLAGS=-D warnings` (what `flake.nix`'s `doc` check runs).
9 rustdoc errors across 3 crates and 7 files:

- **broken_intra_doc_links** — 10 feature-gated module references in
  `graphrag-core/src/rograg/mod.rs` (8) and `graphrag-core/src/storage/mod.rs` (2)
  that don't exist in the default-feature doc build, plus `[mode]` in
  `graphrag-core/src/lib.rs` referring to a TOML section name.
- **invalid_html_tags** — `Vec<f32>` in `graphrag-core/src/vector/mod.rs`,
  `Box<T>` in `graphrag-core/src/core/traits.rs`, and `<file>`/`<name>`/`[filter]`
  in `graphrag-cli/src/commands/mod.rs`'s slash-command examples.
- **bare_urls** — WebLLM URL in `graphrag-wasm/src/webllm.rs` and the
  HippoRAG arxiv URL in `graphrag-core/src/retrieval/hipporag_ppr.rs`.

Fixes are mechanical (backticks for code, `<...>` for URLs, drop link
brackets on feature-gated paths). No code logic changes. 8 files, +20/-20.

## Test plan

- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps` — passes locally on Rust 1.95.0
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings` — passes locally
- [x] `cargo fmt --all --check` — passes locally
- [ ] CI `nix-check` job goes green on this PR

Toolchain matches the CI flake (Rust 1.95.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)