### PR TITLE
fix(embeddings): fail loud instead of returning zero-vector HF embeddings (closes #167)

### DIFF
--- a/graphrag-core/src/embeddings/huggingface.rs
+++ b/graphrag-core/src/embeddings/huggingface.rs
@@ -242,8 +242,7 @@ mod tests {
 
     #[test]
     fn test_new_embeddings() {
-        let embeddings =
-            HuggingFaceEmbeddings::new("sentence-transformers/all-MiniLM-L6-v2", None);
+        let embeddings = HuggingFaceEmbeddings::new("sentence-transformers/all-MiniLM-L6-v2", None);
 
         assert_eq!(
             embeddings.model_id,
@@ -282,8 +281,7 @@ mod tests {
     /// happily consume.
     #[tokio::test]
     async fn embed_returns_err_when_not_initialized() {
-        let embeddings =
-            HuggingFaceEmbeddings::new("sentence-transformers/all-MiniLM-L6-v2", None);
+        let embeddings = HuggingFaceEmbeddings::new("sentence-transformers/all-MiniLM-L6-v2", None);
         let result = embeddings.embed("hello world").await;
         assert!(matches!(result, Err(GraphRAGError::Embedding { .. })));
     }
@@ -304,7 +302,7 @@ mod tests {
                     message.contains("not implemented"),
                     "expected unimplemented message, got: {message}"
                 );
-            }
+            },
             other => panic!("expected Embedding error, got: {other:?}"),
         }
     }

--- a/graphrag-core/src/embeddings/huggingface.rs
+++ b/graphrag-core/src/embeddings/huggingface.rs
@@ -1,10 +1,19 @@
-///! Hugging Face Hub integration for downloading and using embedding models
-///!
-///! This module provides functionality to:
-///! - Download embedding models from Hugging Face Hub
-///! - Cache models locally to avoid re-downloading
-///! - Load models with Candle framework
-///! - Generate embeddings using downloaded models
+//! Hugging Face Hub integration for downloading and using embedding models
+//!
+//! This module provides functionality to:
+//! - Download embedding models from Hugging Face Hub
+//! - Cache models locally to avoid re-downloading
+//! - Load models with Candle framework
+//! - Generate embeddings using downloaded models
+//!
+//! ## Status: local inference unimplemented (#167)
+//!
+//! [`HuggingFaceEmbeddings::embed`] currently returns
+//! [`crate::core::error::GraphRAGError::Embedding`] rather than producing real
+//! vectors — Candle-backed inference has not been wired up yet. Until it is,
+//! callers should use one of the HTTP providers in
+//! [`crate::embeddings::api_providers`].
+
 use crate::core::error::{GraphRAGError, Result};
 use crate::embeddings::{EmbeddingConfig, EmbeddingProvider};
 
@@ -191,24 +200,17 @@ impl EmbeddingProvider for HuggingFaceEmbeddings {
             });
         }
 
-        // TODO: Implement actual embedding generation using Candle
-        // This requires loading the model with candle-transformers
-        // For now, return a placeholder
-
-        #[cfg(feature = "neural-embeddings")]
-        {
-            // Load model with Candle and generate embedding
-            // This is a placeholder - actual implementation would use candle-transformers
-            log::warn!("HuggingFace embedding generation not yet implemented");
-            Ok(vec![0.0; self.dimensions])
-        }
-
-        #[cfg(not(feature = "neural-embeddings"))]
-        {
-            Err(GraphRAGError::Embedding {
-                message: "neural-embeddings feature required for embedding generation".to_string(),
-            })
-        }
+        // Candle-backed local inference is not implemented yet. Returning a
+        // zero vector here would silently feed semantically-meaningless
+        // embeddings through the rest of the pipeline (chunking, vector store,
+        // similarity), so we fail loud instead. Tracked in
+        // stevedores-org/oxidizedRAG#167.
+        Err(GraphRAGError::Embedding {
+            message: "HuggingFace local embedding generation via Candle is not implemented yet \
+                      (issue #167). Use HttpEmbeddingProvider::{openai, voyage_ai, cohere, \
+                      jina_ai, mistral, together_ai} for a working provider."
+                .to_string(),
+        })
     }
 
     async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
@@ -270,5 +272,36 @@ mod tests {
         let result = embeddings.initialize().await;
         assert!(result.is_ok(), "Failed to download model: {:?}", result);
         assert!(embeddings.is_available());
+    }
+
+    /// Regression test for #167: pre-initialize path must fail loud, not
+    /// silently return zero vectors that downstream pipeline stages would
+    /// happily consume.
+    #[tokio::test]
+    async fn embed_returns_err_when_not_initialized() {
+        let embeddings = HuggingFaceEmbeddings::new("sentence-transformers/all-MiniLM-L6-v2", None);
+        let result = embeddings.embed("hello world").await;
+        assert!(matches!(result, Err(GraphRAGError::Embedding { .. })));
+    }
+
+    /// Regression test for #167: even when `initialized = true`, embed must
+    /// return Err until Candle inference actually lands. The previous
+    /// behaviour was `Ok(vec![0.0; dims])` behind the `neural-embeddings`
+    /// feature, which silently corrupted the pipeline.
+    #[tokio::test]
+    async fn embed_returns_err_even_when_marked_initialized() {
+        let mut embeddings =
+            HuggingFaceEmbeddings::new("sentence-transformers/all-MiniLM-L6-v2", None);
+        embeddings.initialized = true;
+        let result = embeddings.embed("hello world").await;
+        match result {
+            Err(GraphRAGError::Embedding { message }) => {
+                assert!(
+                    message.contains("not implemented"),
+                    "expected unimplemented message, got: {message}"
+                );
+            }
+            other => panic!("expected Embedding error, got: {other:?}"),
+        }
     }
 }

--- a/graphrag-core/src/embeddings/huggingface.rs
+++ b/graphrag-core/src/embeddings/huggingface.rs
@@ -209,7 +209,7 @@ impl EmbeddingProvider for HuggingFaceEmbeddings {
             message: concat!(
                 "HuggingFace local embedding generation via Candle is not implemented yet ",
                 "(issue #167). Use HttpEmbeddingProvider::{openai, voyage_ai, cohere, ",
-                "jina_ai, mistral, together_ai} for a working provider."
+                "jina_ai, mistral, together_ai} for a working provider.",
             )
             .to_string(),
         })
@@ -304,7 +304,7 @@ mod tests {
                     message.contains("not implemented"),
                     "expected unimplemented message, got: {message}"
                 );
-            },
+            }
             other => panic!("expected Embedding error, got: {other:?}"),
         }
     }

--- a/graphrag-core/src/embeddings/huggingface.rs
+++ b/graphrag-core/src/embeddings/huggingface.rs
@@ -304,7 +304,7 @@ mod tests {
                     message.contains("not implemented"),
                     "expected unimplemented message, got: {message}"
                 );
-            }
+            },
             other => panic!("expected Embedding error, got: {other:?}"),
         }
     }

--- a/graphrag-core/src/embeddings/huggingface.rs
+++ b/graphrag-core/src/embeddings/huggingface.rs
@@ -206,10 +206,12 @@ impl EmbeddingProvider for HuggingFaceEmbeddings {
         // similarity), so we fail loud instead. Tracked in
         // stevedores-org/oxidizedRAG#167.
         Err(GraphRAGError::Embedding {
-            message: "HuggingFace local embedding generation via Candle is not implemented yet \
-                      (issue #167). Use HttpEmbeddingProvider::{openai, voyage_ai, cohere, \
-                      jina_ai, mistral, together_ai} for a working provider."
-                .to_string(),
+            message: concat!(
+                "HuggingFace local embedding generation via Candle is not implemented yet ",
+                "(issue #167). Use HttpEmbeddingProvider::{openai, voyage_ai, cohere, ",
+                "jina_ai, mistral, together_ai} for a working provider."
+            )
+            .to_string(),
         })
     }
 
@@ -240,7 +242,8 @@ mod tests {
 
     #[test]
     fn test_new_embeddings() {
-        let embeddings = HuggingFaceEmbeddings::new("sentence-transformers/all-MiniLM-L6-v2", None);
+        let embeddings =
+            HuggingFaceEmbeddings::new("sentence-transformers/all-MiniLM-L6-v2", None);
 
         assert_eq!(
             embeddings.model_id,
@@ -279,7 +282,8 @@ mod tests {
     /// happily consume.
     #[tokio::test]
     async fn embed_returns_err_when_not_initialized() {
-        let embeddings = HuggingFaceEmbeddings::new("sentence-transformers/all-MiniLM-L6-v2", None);
+        let embeddings =
+            HuggingFaceEmbeddings::new("sentence-transformers/all-MiniLM-L6-v2", None);
         let result = embeddings.embed("hello world").await;
         assert!(matches!(result, Err(GraphRAGError::Embedding { .. })));
     }

--- a/graphrag-core/src/embeddings/neural.rs
+++ b/graphrag-core/src/embeddings/neural.rs
@@ -1,6 +1,20 @@
 //! Neural embedding models using Candle for local inference.
 //!
 //! This module is gated behind the `neural-embeddings` feature flag.
-//! It provides local embedding generation using Candle transformer models.
+//!
+//! ## Status
+//!
+//! Not implemented. Tracked in stevedores-org/oxidizedRAG#167. The previous
+//! placeholder (a one-line `// TODO`) led the feature flag to advertise a
+//! capability the crate did not provide. Until a real `NeuralEmbeddingProvider`
+//! lands, attempting to use the local-Candle path on
+//! [`crate::embeddings::huggingface::HuggingFaceEmbeddings`] returns
+//! [`crate::core::error::GraphRAGError::Embedding`] rather than silently
+//! producing zero vectors.
+//!
+//! Use one of the HTTP providers in [`crate::embeddings::api_providers`]
+//! (`HttpEmbeddingProvider::{openai, voyage_ai, cohere, jina_ai, mistral,
+//! together_ai}`) until local inference is wired up.
 
-// TODO: Implement NeuralEmbeddingProvider using candle-transformers
+// Intentionally empty. Adding a real `NeuralEmbeddingProvider` is the next
+// step on #167. Until then the module exists only to document the gap.


### PR DESCRIPTION
## Summary

- `HuggingFaceEmbeddings::embed` now returns `Err(GraphRAGError::Embedding)` instead of silently emitting `vec![0.0; dims]` when Candle inference is invoked. Closes #167.
- `graphrag-core/src/embeddings/neural.rs` rewritten from a one-line `// TODO` into a module-level doc that names the gap and points callers at the working `HttpEmbeddingProvider` alternatives.
- Two regression tests cover both the not-initialized and marked-initialized paths, asserting the error and its message.
- Drive-by: fix `///!` → `//!` at the top of `huggingface.rs` (clippy `suspicious_doc_comments`).

## Why

The previous behaviour passed zero vectors through the rest of the pipeline (chunking, vector store, similarity), producing structurally-clean retrieval results with no semantic meaning. The only signal was a `log::warn!`, which is easy to miss in production logs. This was misleading enough that the README quickstart had to be rewritten away from HuggingFace in a follow-up to PR #164.

Real Candle-backed inference is the next step on the same issue and on phase 1.1 of the meta-epic (#182 / [TDD](https://github.com/stevedores-org/oxidizedRAG/blob/develop/docs/tdd-multimodal-and-service.md)). Failing loud is the prerequisite — it stops silently-wrong embeddings from shipping while the real implementation gets written.

## Test plan

- [x] `cargo test -p graphrag-core --features huggingface-hub --lib embeddings::huggingface` — 5/5 pass (3 pre-existing + 2 new regression tests)
- [x] `cargo test -p graphrag-core --lib` — 363/363 pass
- [x] `cargo clippy -p graphrag-core --features huggingface-hub --all-targets -- -D warnings` clean
- [ ] CI green on PR

## Refs

- Closes #167
- Part of meta-epic #182, phase 1.1
- TDD: `docs/tdd-multimodal-and-service.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)