### PR TITLE
ci: parallelize nix flake checks (smaller parallel jobs)

### DIFF
--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -1,0 +1,13 @@
+name: Nix setup
+description: Install Nix with the stevedores org substituter trusted
+
+runs:
+  using: composite
+  steps:
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@v14
+      with:
+        extra-conf: |
+          extra-substituters = https://nix-cache.stevedores.org/
+          extra-trusted-substituters = https://nix-cache.stevedores.org/
+          extra-trusted-public-keys = stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,42 +7,88 @@ on:
     branches: [develop, main]
 
 jobs:
+  # One flake check per job so fmt/clippy/build/doc/benches run in parallel.
+  # `tests` is still the long pole; nextest partitions (flake.nix) parallelize
+  # partition derivations on the runner via Nix.
   nix-check:
+    name: nix ${{ matrix.check }}
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - check: fmt
+            timeout: 15
+          - check: clippy
+            timeout: 45
+          - check: workspace
+            timeout: 45
+          - check: benches
+            timeout: 45
+          - check: doc
+            timeout: 30
+          - check: tests
+            timeout: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Install Nix with the org's substituter pre-configured as trusted.
-      # The flake.nix's nixConfig.extra-substituters is otherwise ignored
-      # as "untrusted flake configuration" — only nix.conf entries from a
-      # trusted source (here: the installer's extra-conf, which writes
-      # /etc/nix/nix.conf as root) are honored.
-      #
-      # We deliberately do NOT use DeterminateSystems/magic-nix-cache-action.
-      # It depends on FlakeHub authentication, which the org doesn't run, so
-      # every PR was failing with "Unable to authenticate to FlakeHub" and
-      # cascading "substituter disabled" errors. The org's own cache replaces
-      # that role.
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
-        with:
-          extra-conf: |
-            extra-substituters = https://nix-cache.stevedores.org/
-            extra-trusted-substituters = https://nix-cache.stevedores.org/
-            extra-trusted-public-keys = stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A=
+      - name: Nix setup
+        uses: ./.github/actions/nix-setup
 
-      - name: Flake check
-        run: nix flake check --print-build-logs
+      - name: Build flake check (${{ matrix.check }})
+        run: |
+          set -euo pipefail
+          system=$(nix eval --impure --raw --expr 'builtins.currentSystem')
+          nix build ".#checks.${system}.${{ matrix.check }}" --print-build-logs
 
-      - name: Workspace tests
-        run: nix develop --command cargo test --workspace
+  incremental-correctness:
+    name: incremental correctness
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Nix setup
+        uses: ./.github/actions/nix-setup
 
       - name: Incremental correctness tests
-        run: nix develop --command cargo test -p graphrag-core --features "incremental,async" --test incremental_correctness_test --verbose
+        run: |
+          nix develop --command cargo test -p graphrag-core \
+            --features "incremental,async" \
+            --test incremental_correctness_test --verbose
+
+  incremental-perf:
+    name: incremental perf gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Nix setup
+        uses: ./.github/actions/nix-setup
 
       - name: Incremental performance gate (<5% overhead)
-        run: nix develop --command cargo test -p graphrag-core --features "incremental,async" --test incremental_perf_test --verbose -- --nocapture
+        run: |
+          nix develop --command cargo test -p graphrag-core \
+            --features "incremental,async" \
+            --test incremental_perf_test --verbose -- --nocapture
+
+  surrealdb:
+    name: surrealdb storage
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Nix setup
+        uses: ./.github/actions/nix-setup
 
       - name: SurrealDB storage tests
-        run: nix develop --command cargo test -p graphrag-core --features "surrealdb-storage" surrealdb
+        run: |
+          nix develop --command cargo test -p graphrag-core \
+            --features "surrealdb-storage" surrealdb

--- a/flake.nix
+++ b/flake.nix
@@ -66,9 +66,10 @@
         # Build workspace deps first (for caching)
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
-        # Build the full workspace
+        # Compile gate only — `checks.tests` runs the workspace via nextest.
         workspace = craneLib.buildPackage (commonArgs // {
           inherit cargoArtifacts;
+          doCheck = false;
         });
       in
       {
@@ -86,13 +87,16 @@
 
           tests = craneLib.cargoNextest (commonArgs // {
             inherit cargoArtifacts;
-            partitions = 1;
+            # Partitioned nextest: Nix builds/runs each partition in parallel on the runner.
+            partitions = 4;
             partitionType = "count";
           });
 
           benches = craneLib.buildPackage (commonArgs // {
             inherit cargoArtifacts;
+            # `cargo build --benches` compiles bench targets; doCheck=false skips tests.
             cargoExtraArgs = "--workspace --benches";
+            doCheck = false;
           });
 
           doc = craneLib.cargoDoc (commonArgs // {


### PR DESCRIPTION
## Summary

Replaces the monolithic `nix-check` job (single `nix flake check`, up to 120m) with **10 parallel jobs**:

| Job | What it runs | Timeout |
|-----|----------------|---------|
| `nix fmt` | `checks.fmt` | 15m |
| `nix clippy` | `checks.clippy` | 45m |
| `nix workspace` | `checks.workspace` (compile-only) | 45m |
| `nix benches` | `checks.benches` (compile-only) | 45m |
| `nix doc` | `checks.doc` | 30m |
| `nix tests` | `checks.tests` (nextest, 4 partitions) | 90m |
| `incremental correctness` | feature-gated integration test | 30m |
| `incremental perf gate` | perf regression test | 30m |
| `surrealdb storage` | surrealdb feature tests | 30m |

**Wall-clock CI** becomes ~`max(jobs)` instead of ~`sum(jobs)`.

### Flake changes
- `workspace` / `benches`: `doCheck = false` (compile gates only; nextest owns tests)
- `tests`: `partitions = 4` so Nix builds/runs nextest partitions in parallel on the runner

### Other
- Shared Nix install extracted to `.github/actions/nix-setup`
- Drops duplicate `cargo test --workspace` (already covered by `checks.tests`)

## Test plan

- [ ] All 10 CI jobs green on this PR
- [ ] Faster feedback on fmt/clippy failures (no longer blocked behind full flake check)


Made with [Cursor](https://cursor.com)