### PR TITLE
ci: parallel flake checks, multi-runner tests, docs path filters

### DIFF
--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -1,0 +1,13 @@
+name: Nix setup
+description: Install Nix with the stevedores org substituter trusted
+
+runs:
+  using: composite
+  steps:
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@v14
+      with:
+        extra-conf: |
+          extra-substituters = https://nix-cache.stevedores.org/
+          extra-trusted-substituters = https://nix-cache.stevedores.org/
+          extra-trusted-public-keys = stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,42 +7,88 @@ on:
     branches: [develop, main]
 
 jobs:
+  # One flake check per job so fmt/clippy/build/doc/benches run in parallel.
+  # `tests` is still the long pole; nextest partitions (flake.nix) parallelize
+  # partition derivations on the runner via Nix.
   nix-check:
+    name: nix ${{ matrix.check }}
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - check: fmt
+            timeout: 15
+          - check: clippy
+            timeout: 45
+          - check: workspace
+            timeout: 45
+          - check: benches
+            timeout: 45
+          - check: doc
+            timeout: 30
+          - check: tests
+            timeout: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Install Nix with the org's substituter pre-configured as trusted.
-      # The flake.nix's nixConfig.extra-substituters is otherwise ignored
-      # as "untrusted flake configuration" — only nix.conf entries from a
-      # trusted source (here: the installer's extra-conf, which writes
-      # /etc/nix/nix.conf as root) are honored.
-      #
-      # We deliberately do NOT use DeterminateSystems/magic-nix-cache-action.
-      # It depends on FlakeHub authentication, which the org doesn't run, so
-      # every PR was failing with "Unable to authenticate to FlakeHub" and
-      # cascading "substituter disabled" errors. The org's own cache replaces
-      # that role.
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
-        with:
-          extra-conf: |
-            extra-substituters = https://nix-cache.stevedores.org/
-            extra-trusted-substituters = https://nix-cache.stevedores.org/
-            extra-trusted-public-keys = stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A=
+      - name: Nix setup
+        uses: ./.github/actions/nix-setup
 
-      - name: Flake check
-        run: nix flake check --print-build-logs
+      - name: Build flake check (${{ matrix.check }})
+        run: |
+          set -euo pipefail
+          system=$(nix eval --impure --raw --expr 'builtins.currentSystem')
+          nix build ".#checks.${system}.${{ matrix.check }}" --print-build-logs
 
-      - name: Workspace tests
-        run: nix develop --command cargo test --workspace
+  incremental-correctness:
+    name: incremental correctness
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Nix setup
+        uses: ./.github/actions/nix-setup
 
       - name: Incremental correctness tests
-        run: nix develop --command cargo test -p graphrag-core --features "incremental,async" --test incremental_correctness_test --verbose
+        run: |
+          nix develop --command cargo test -p graphrag-core \
+            --features "incremental,async" \
+            --test incremental_correctness_test --verbose
+
+  incremental-perf:
+    name: incremental perf gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Nix setup
+        uses: ./.github/actions/nix-setup
 
       - name: Incremental performance gate (<5% overhead)
-        run: nix develop --command cargo test -p graphrag-core --features "incremental,async" --test incremental_perf_test --verbose -- --nocapture
+        run: |
+          nix develop --command cargo test -p graphrag-core \
+            --features "incremental,async" \
+            --test incremental_perf_test --verbose -- --nocapture
+
+  surrealdb:
+    name: surrealdb storage
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Nix setup
+        uses: ./.github/actions/nix-setup
 
       - name: SurrealDB storage tests
-        run: nix develop --command cargo test -p graphrag-core --features "surrealdb-storage" surrealdb
+        run: |
+          nix develop --command cargo test -p graphrag-core \
+            --features "surrealdb-storage" surrealdb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,51 @@ on:
   push:
     branches: [develop, main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  # One flake check per job so fmt/clippy/build/doc/benches run in parallel.
-  # `tests` is still the long pole; nextest partitions (flake.nix) parallelize
-  # partition derivations on the runner via Nix.
+  changes:
+    name: detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify changes
+        id: filter
+        run: |
+          set -euo pipefail
+          # Always run the full matrix on long-lived branch pushes.
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          base="${{ github.event.pull_request.base.sha }}"
+          if git diff --name-only "${base}...HEAD" | grep -qE \
+            '\.(rs|toml|lock)$|^(flake\.nix|flake\.lock|justfile|rustfmt\.toml)(/|$)|^\.github/|^benches/|^graphrag-'; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rust=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  docs-only:
+    name: docs only (rust checks skipped)
+    needs: changes
+    if: needs.changes.outputs.rust != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No Rust/workspace paths changed — skipping nix compile and test jobs."
+
   nix-check:
     name: nix ${{ matrix.check }}
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: ${{ matrix.timeout }}
     strategy:
@@ -28,8 +67,29 @@ jobs:
             timeout: 45
           - check: doc
             timeout: 30
-          - check: tests
-            timeout: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Nix setup
+        uses: ./.github/actions/nix-setup
+
+      - name: Build flake check (${{ matrix.check }})
+        run: |
+          set -euo pipefail
+          system=$(nix eval --impure --raw --expr 'builtins.currentSystem')
+          nix build ".#checks.${system}.${{ matrix.check }}" --print-build-logs
+
+  nix-tests:
+    name: nix ${{ matrix.check }}
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        check: [tests-p1, tests-p2, tests-p3, tests-p4]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,6 +105,8 @@ jobs:
 
   incremental-correctness:
     name: incremental correctness
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -62,6 +124,8 @@ jobs:
 
   incremental-perf:
     name: incremental perf gate
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -79,6 +143,8 @@ jobs:
 
   surrealdb:
     name: surrealdb storage
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -66,11 +66,29 @@
         # Build workspace deps first (for caching)
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
-        # Compile gate only — `checks.tests` runs the workspace via nextest.
+        # Compile gate only — `checks.tests-p*` runs the workspace via nextest.
         workspace = craneLib.buildPackage (commonArgs // {
           inherit cargoArtifacts;
           doCheck = false;
         });
+
+        # One flake check per nextest partition so CI can fan out across runners.
+        nextestPartitionCount = 4;
+        testPartitionChecks = builtins.listToAttrs (
+          map (n:
+            let name = "tests-p${toString n}";
+            in {
+              inherit name;
+              value = craneLib.cargoNextest (commonArgs // {
+                inherit cargoArtifacts;
+                partitions = 1;
+                partitionType = "count";
+                cargoNextestPartitionsExtraArgs =
+                  "--partition count:${toString n}/${toString nextestPartitionCount}";
+              });
+            }
+          ) (builtins.genList (n: n + 1) nextestPartitionCount)
+        );
       in
       {
         checks = {
@@ -84,13 +102,7 @@
           fmt = craneLib.cargoFmt {
             src = craneLib.cleanCargoSource ./.;
           };
-
-          tests = craneLib.cargoNextest (commonArgs // {
-            inherit cargoArtifacts;
-            # Partitioned nextest: Nix builds/runs each partition in parallel on the runner.
-            partitions = 4;
-            partitionType = "count";
-          });
+        } // testPartitionChecks // {
 
           benches = craneLib.buildPackage (commonArgs // {
             inherit cargoArtifacts;

--- a/flake.nix
+++ b/flake.nix
@@ -66,9 +66,10 @@
         # Build workspace deps first (for caching)
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
-        # Build the full workspace
+        # Compile gate only — `checks.tests` runs the workspace via nextest.
         workspace = craneLib.buildPackage (commonArgs // {
           inherit cargoArtifacts;
+          doCheck = false;
         });
       in
       {
@@ -86,13 +87,16 @@
 
           tests = craneLib.cargoNextest (commonArgs // {
             inherit cargoArtifacts;
-            partitions = 1;
+            # Partitioned nextest: Nix builds/runs each partition in parallel on the runner.
+            partitions = 4;
             partitionType = "count";
           });
 
           benches = craneLib.buildPackage (commonArgs // {
             inherit cargoArtifacts;
+            # `cargo build --benches` compiles bench targets; doCheck=false skips tests.
             cargoExtraArgs = "--workspace --benches";
+            doCheck = false;
           });
 
           doc = craneLib.cargoDoc (commonArgs // {


### PR DESCRIPTION
## Summary

Stacks on the parallel CI split from #192 and adds the next two optimizations:

### Multi-runner test partitions
- Replaces single `checks.tests` with **`tests-p1` … `tests-p4`** flake checks
- Each runs `cargo nextest --partition count:N/4` on its own GHA runner (~30m timeout each)
- Test wall-clock should drop to ~max(partition) instead of one 90m job

### Docs-only path filters
- New `changes` job classifies PR diffs (Rust/workspace vs docs-only)
- **Docs-only PRs** (e.g. markdown/planning) skip nix clippy/tests/benches/feature jobs
- **Push to `develop`/`main`** always runs the full matrix
- Adds workflow **concurrency** (`cancel-in-progress`) to stop superseded runs

### Already in this branch (from #192)
- Matrix jobs for fmt / clippy / workspace / benches / doc
- Shared `.github/actions/nix-setup`
- `workspace` + `benches` compile-only (`doCheck = false`)

## CI layout (rust-changing PRs)

| Job | Count |
|-----|-------|
| `nix fmt` | 1 |
| `nix clippy` | 1 |
| `nix workspace` | 1 |
| `nix benches` | 1 |
| `nix doc` | 1 |
| `nix tests-p1` … `tests-p4` | 4 |
| incremental + surrealdb | 3 |

**13 parallel rust jobs** + lightweight `docs only` pass for markdown-only PRs.

## Test plan

- [ ] Rust-touching PR: all 13 jobs run in parallel
- [ ] Docs-only PR: only `detect changed paths` + `docs only` green
- [ ] `nix-cache` still enumerates all flake checks (including `tests-p*`)

Closes #192 if merged together; otherwise supersedes it.


Made with [Cursor](https://cursor.com)