### PR TITLE
fix: DashMap deadlock, NaN-safe sorts, clock-skew-safe rate limiter

### DIFF
--- a/graphrag-core/src/graph/incremental.rs
+++ b/graphrag-core/src/graph/incremental.rs
@@ -1662,7 +1662,12 @@ impl BatchProcessor {
     pub async fn add_change(&self, change: ChangeRecord) -> Result<String> {
         let batch_key = self.get_batch_key(&change);
 
-        let batch_id = {
+        // `entry()` returns a `RefMut` holding the shard's write lock.
+        // Calling `remove()` on the same key while that guard is alive would
+        // re-enter the shard lock and deadlock. Instead, atomically swap the
+        // entry value with a fresh empty batch when full, drop the guard, and
+        // process the captured batch outside the lock.
+        let (batch_id, batch_to_process) = {
             let mut entry = self
                 .pending_batches
                 .entry(batch_key.clone())
@@ -1679,21 +1684,28 @@ impl BatchProcessor {
             let batch_id = entry.batch_id.clone();
 
             if should_process {
-                // Move batch out for processing
-                let batch = entry.clone();
-                self.pending_batches.remove(&batch_key);
-
-                // Process batch asynchronously
-                let processor = Arc::new(self.clone());
-                tokio::spawn(async move {
-                    if let Err(e) = processor.process_batch(batch).await {
-                        eprintln!("Batch processing error: {e}");
-                    }
-                });
+                let full_batch = std::mem::replace(
+                    entry.value_mut(),
+                    PendingBatch {
+                        changes: Vec::new(),
+                        created_at: Instant::now(),
+                        batch_id: format!("batch_{}", Uuid::new_v4()),
+                    },
+                );
+                (batch_id, Some(full_batch))
+            } else {
+                (batch_id, None)
             }
-
-            batch_id
         };
+
+        if let Some(batch) = batch_to_process {
+            let processor = Arc::new(self.clone());
+            tokio::spawn(async move {
+                if let Err(e) = processor.process_batch(batch).await {
+                    eprintln!("Batch processing error: {e}");
+                }
+            });
+        }
 
         Ok(batch_id)
     }

--- a/graphrag-core/src/retrieval/adaptive.rs
+++ b/graphrag-core/src/retrieval/adaptive.rs
@@ -244,7 +244,7 @@ impl AdaptiveRetriever {
         }
 
         // Sort by final weighted score
-        deduplicated_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        deduplicated_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
 
         // Apply diversity-aware selection
         let final_results = self.diversity_aware_selection(deduplicated_results, max_results);

--- a/graphrag-core/src/retrieval/adaptive.rs
+++ b/graphrag-core/src/retrieval/adaptive.rs
@@ -244,7 +244,11 @@ impl AdaptiveRetriever {
         }
 
         // Sort by final weighted score
-        deduplicated_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        deduplicated_results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         // Apply diversity-aware selection
         let final_results = self.diversity_aware_selection(deduplicated_results, max_results);

--- a/graphrag-core/src/retrieval/bm25.rs
+++ b/graphrag-core/src/retrieval/bm25.rs
@@ -146,7 +146,11 @@ impl BM25Retriever {
             })
             .collect();
 
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         results.truncate(limit);
         results
     }

--- a/graphrag-core/src/retrieval/bm25.rs
+++ b/graphrag-core/src/retrieval/bm25.rs
@@ -146,7 +146,7 @@ impl BM25Retriever {
             })
             .collect();
 
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
         results.truncate(limit);
         results
     }

--- a/graphrag-core/src/retrieval/enriched.rs
+++ b/graphrag-core/src/retrieval/enriched.rs
@@ -216,7 +216,11 @@ impl EnrichedRetriever {
         }
 
         // Re-sort after boosting
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         Ok(results)
     }
@@ -285,7 +289,11 @@ impl EnrichedRetriever {
         }
 
         let mut sorted_results: Vec<_> = keyword_scores.into_iter().collect();
-        sorted_results.sort_by(|a, b| b.1 .0.partial_cmp(&a.1 .0).unwrap_or(std::cmp::Ordering::Equal));
+        sorted_results.sort_by(|a, b| {
+            b.1 .0
+                .partial_cmp(&a.1 .0)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         sorted_results
             .into_iter()

--- a/graphrag-core/src/retrieval/enriched.rs
+++ b/graphrag-core/src/retrieval/enriched.rs
@@ -216,7 +216,7 @@ impl EnrichedRetriever {
         }
 
         // Re-sort after boosting
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
 
         Ok(results)
     }
@@ -285,7 +285,7 @@ impl EnrichedRetriever {
         }
 
         let mut sorted_results: Vec<_> = keyword_scores.into_iter().collect();
-        sorted_results.sort_by(|a, b| b.1 .0.partial_cmp(&a.1 .0).unwrap());
+        sorted_results.sort_by(|a, b| b.1 .0.partial_cmp(&a.1 .0).unwrap_or(std::cmp::Ordering::Equal));
 
         sorted_results
             .into_iter()

--- a/graphrag-core/src/retrieval/hybrid.rs
+++ b/graphrag-core/src/retrieval/hybrid.rs
@@ -471,7 +471,11 @@ impl HybridRetriever {
             .collect();
 
         // Sort by combined score
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         results.truncate(limit);
 
         Ok(results)

--- a/graphrag-core/src/retrieval/hybrid.rs
+++ b/graphrag-core/src/retrieval/hybrid.rs
@@ -471,7 +471,7 @@ impl HybridRetriever {
             .collect();
 
         // Sort by combined score
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
         results.truncate(limit);
 
         Ok(results)

--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -1127,7 +1127,7 @@ impl RetrievalSystem {
         }
 
         // Sort by adjusted scores
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
 
         // Diversity-aware deduplication
         let mut deduplicated = Vec::new();
@@ -1251,7 +1251,7 @@ impl RetrievalSystem {
 
         // Select top entities by combined score
         let mut sorted_entities: Vec<_> = entity_scores.iter().collect();
-        sorted_entities.sort_by(|a, b| b.1.partial_cmp(a.1).unwrap());
+        sorted_entities.sort_by(|a, b| b.1.partial_cmp(a.1).unwrap_or(std::cmp::Ordering::Equal));
 
         for (entity_id, score) in sorted_entities.iter().take(3) {
             if let Some(entity) = graph.entities().find(|e| e.id.to_string() == **entity_id) {
@@ -1372,7 +1372,7 @@ impl RetrievalSystem {
         }
 
         // Sort by similarity
-        similarities.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        similarities.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
         Ok(similarities)
     }
@@ -1430,7 +1430,7 @@ impl RetrievalSystem {
     /// Rank and deduplicate search results (legacy)
     fn rank_and_deduplicate(&self, mut results: Vec<SearchResult>) -> Result<Vec<SearchResult>> {
         // Sort by score descending
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
 
         // Deduplicate by ID
         let mut seen_ids = HashSet::new();

--- a/graphrag-core/src/retrieval/mod.rs
+++ b/graphrag-core/src/retrieval/mod.rs
@@ -1127,7 +1127,11 @@ impl RetrievalSystem {
         }
 
         // Sort by adjusted scores
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         // Diversity-aware deduplication
         let mut deduplicated = Vec::new();
@@ -1430,7 +1434,11 @@ impl RetrievalSystem {
     /// Rank and deduplicate search results (legacy)
     fn rank_and_deduplicate(&self, mut results: Vec<SearchResult>) -> Result<Vec<SearchResult>> {
         // Sort by score descending
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         // Deduplicate by ID
         let mut seen_ids = HashSet::new();

--- a/graphrag-core/src/retrieval/pagerank_retrieval.rs
+++ b/graphrag-core/src/retrieval/pagerank_retrieval.rs
@@ -214,7 +214,11 @@ impl PageRankRetrievalSystem {
         }
 
         // Step 5: Sort by combined score and limit results
-        scored_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        scored_results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         scored_results.truncate(max_results);
 
         println!(
@@ -356,7 +360,11 @@ impl PageRankRetrievalSystem {
             }
         }
 
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         results.truncate(self.max_results);
 
         results

--- a/graphrag-core/src/retrieval/pagerank_retrieval.rs
+++ b/graphrag-core/src/retrieval/pagerank_retrieval.rs
@@ -214,7 +214,7 @@ impl PageRankRetrievalSystem {
         }
 
         // Step 5: Sort by combined score and limit results
-        scored_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        scored_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
         scored_results.truncate(max_results);
 
         println!(
@@ -356,7 +356,7 @@ impl PageRankRetrievalSystem {
             }
         }
 
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
         results.truncate(self.max_results);
 
         results

--- a/graphrag-server/src/auth.rs
+++ b/graphrag-server/src/auth.rs
@@ -210,8 +210,10 @@ impl AuthState {
 
         let (count, window_start) = rate_limits.entry(user_id.to_string()).or_insert((0, now));
 
-        // Reset if window expired
-        if now - *window_start >= limit.window_seconds {
+        // Reset if window expired. `saturating_sub` keeps a clock that ran
+        // backward (e.g. an NTP step) from panicking in debug or wrapping in
+        // release — both would silently reset the limiter on the next request.
+        if now.saturating_sub(*window_start) >= limit.window_seconds {
             *count = 0;
             *window_start = now;
         }


### PR DESCRIPTION
## Summary

Three independent bug fixes surfaced during a broader audit. Each commit is self-contained and reviewable on its own.

### 1. `graph::incremental::add_change` — DashMap shard-lock deadlock (BLOCKER)

`add_change` was calling `pending_batches.remove(&batch_key)` while still holding the `RefMut` from `entry()`. DashMap's `entry()` holds the shard's write lock; `remove()` re-enters that lock on the same shard → hang. **Every time a batch reaches `batch_size`** (i.e. the common case), the calling task blocks forever.

Fix: swap the populated batch for a fresh empty one with `mem::replace` inside the entry guard, drop the guard, and process outside. Atomic, no deadlock, no race window.

### 2. `retrieval::*` — `partial_cmp(...).unwrap()` panic on NaN (HIGH)

Eleven score-sort sites across `hybrid`, `bm25`, `pagerank_retrieval`, `enriched`, `adaptive`, and `mod.rs` would crash the retrieval thread on the first NaN score. Replaced with `.unwrap_or(std::cmp::Ordering::Equal)`, matching what `retrieval::fusion` already does.

### 3. `server::auth` — backward clock skew breaks rate limiter (MEDIUM)

`now - *window_start` is u64 subtraction. NTP step → debug build panics, release build wraps to a huge value that's trivially `>= window_seconds` and silently resets the limiter. `saturating_sub` fixes both regimes.

## Other findings from the audit (not in this PR)

The audit surfaced ~10 more issues — flagging here so they can be triaged:

| Severity | Location | Issue |
|---|---|---|
| HIGH | `retrieval::fusion::policy_from_config` | `WeightedSum` policy uses `weights.keywords` as the vector weight; `FusionWeights` has no `vector` field |
| HIGH | `wasm::onnx_embedder::extract_embedding` | `Reflect::get` returning `undefined` makes the `pooler_output` fallback unreachable |
| HIGH | `wasm::onnx_embedder` mean-pool | Pools over padding tokens; short queries are systematically diluted |
| HIGH | `retrieval::bm25::index_document` | Stores normalized TF, then BM25 formula normalizes again — length penalty applied twice |
| HIGH | `graph::pagerank` | Sequential and parallel kernels disagree on out-degree (count vs. weight sum) |
| HIGH | `async_processing::concurrent_pipeline` | `SemaphorePermit<'_>` is `'static`-incompatible with `tokio::spawn`; needs `OwnedSemaphorePermit` |
| MEDIUM | `retrieval::hipporag_ppr` | `>= min_entity_frequency` filter is inverted vs. comment intent |
| MEDIUM | `graph::leiden` | Modularity-delta missing `-degree` term |
| MEDIUM | `text::semantic_chunking` | `buffer_size > 1` produces off-by-`buffer_size-1` breakpoints |
| MEDIUM | `wasm::storage` | Both IDB closures `.forget()`ed; one always leaks per request |

Happy to take any of these as follow-up PRs.

## Test plan

- [x] `cargo check -p graphrag-core` clean
- [x] `cargo check -p graphrag-server` clean
- [x] `cargo test -p graphrag-core --lib graph::incremental` (21 pass)
- [x] `cargo test -p graphrag-core --lib retrieval` (16 pass)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)