### PR TITLE
fix(fusion): wire FusionWeights to WeightedSum by retrieval source

### DIFF
--- a/examples/complete_zero_cost_graphrag_demo.rs
+++ b/examples/complete_zero_cost_graphrag_demo.rs
@@ -235,9 +235,10 @@ fn create_pure_algorithmic_config() -> Config {
                         enabled: true,
                         policy: "weighted_sum".to_string(),
                         weights: graphrag_core::config::FusionWeights {
-                            keywords: 0.4,
+                            vector: 0.4,
+                            keywords: 0.2,
                             graph: 0.4,
-                            bm25: 0.2,
+                            bm25: 0.0,
                         },
                         rrf_k: 60.0,
                         cascade_early_stop_score: 0.9,

--- a/graphrag-core/examples/complete_zero_cost_graphrag_demo.rs
+++ b/graphrag-core/examples/complete_zero_cost_graphrag_demo.rs
@@ -310,9 +310,10 @@ fn create_pure_algorithmic_config() -> Config {
                         enabled: true,
                         policy: "weighted_sum".to_string(),
                         weights: graphrag_core::config::FusionWeights {
-                            keywords: 0.4,
+                            vector: 0.4,
+                            keywords: 0.2,
                             graph: 0.4,
-                            bm25: 0.2,
+                            bm25: 0.0,
                         },
                         rrf_k: 60.0,
                         cascade_early_stop_score: 0.9,

--- a/graphrag-core/src/config/mod.rs
+++ b/graphrag-core/src/config/mod.rs
@@ -568,15 +568,22 @@ pub struct HybridFusionConfig {
 
 /// Weight configuration for combining different search strategies.
 ///
-/// Defines the relative importance of each search approach in the
+/// Defines the relative importance of each retrieval source in the
 /// hybrid fusion algorithm. Weights should typically sum to 1.0.
+///
+/// The three retrieval sources match `RetrievalSource::{Vector, Keyword, Graph}`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FusionWeights {
-    /// Weight for keyword-based search results
+    /// Weight for vector / embedding-similarity search results.
+    #[serde(default = "default_vector_weight")]
+    pub vector: f32,
+    /// Weight for keyword (BM25/TF-IDF) search results.
     pub keywords: f32,
-    /// Weight for graph traversal-based search results
+    /// Weight for graph traversal-based search results.
     pub graph: f32,
-    /// Weight for BM25/TF-IDF statistical search results
+    /// Deprecated: retained for config backward compatibility. The keyword-source
+    /// weight is now driven by `keywords`. Will be removed in a future release.
+    #[serde(default)]
     pub bm25: f32,
 }
 
@@ -786,9 +793,10 @@ impl Default for SearchRankingConfig {
                 enabled: true,
                 policy: default_fusion_policy(),
                 weights: FusionWeights {
-                    keywords: 0.4,
+                    vector: 0.4,
+                    keywords: 0.2,
                     graph: 0.4,
-                    bm25: 0.2,
+                    bm25: 0.0,
                 },
                 rrf_k: default_rrf_k(),
                 cascade_early_stop_score: default_cascade_early_stop_score(),
@@ -848,9 +856,10 @@ impl Default for HybridFusionConfig {
             enabled: true,
             policy: default_fusion_policy(),
             weights: FusionWeights {
-                keywords: 0.4,
+                vector: 0.4,
+                keywords: 0.2,
                 graph: 0.4,
-                bm25: 0.2,
+                bm25: 0.0,
             },
             rrf_k: default_rrf_k(),
             cascade_early_stop_score: default_cascade_early_stop_score(),
@@ -860,9 +869,10 @@ impl Default for HybridFusionConfig {
 impl Default for FusionWeights {
     fn default() -> Self {
         Self {
-            keywords: 0.4,
+            vector: 0.4,
+            keywords: 0.2,
             graph: 0.4,
-            bm25: 0.2,
+            bm25: 0.0,
         }
     }
 }
@@ -1104,6 +1114,9 @@ fn default_rrf_k() -> f32 {
 }
 fn default_cascade_early_stop_score() -> f32 {
     0.9
+}
+fn default_vector_weight() -> f32 {
+    0.4
 }
 fn default_search_algorithm() -> String {
     "cosine".to_string()

--- a/graphrag-core/src/retrieval/fusion.rs
+++ b/graphrag-core/src/retrieval/fusion.rs
@@ -190,8 +190,8 @@ pub fn policy_from_config(config: &HybridFusionConfig) -> Box<dyn FusionPolicy> 
             early_stop_score: config.cascade_early_stop_score,
         }),
         _ => Box::new(WeightedSum {
-            vector_weight: config.weights.keywords,
-            keyword_weight: config.weights.bm25,
+            vector_weight: config.weights.vector,
+            keyword_weight: config.weights.keywords,
             graph_weight: config.weights.graph,
         }),
     }


### PR DESCRIPTION
## Summary

Audit finding (HIGH) from PR #195: `policy_from_config` was assigning weights to the wrong sources.

\`\`\`rust
// before
WeightedSum {
    vector_weight:  config.weights.keywords,  // wrong field
    keyword_weight: config.weights.bm25,      // wrong field
    graph_weight:   config.weights.graph,
}
\`\`\`

\`FusionWeights\` had no \`vector\` field at all. The keyword-source weight was being driven by \`bm25\`, and the vector axis was being driven by \`keywords\`. Every fused score on the WeightedSum branch (the default) was scored against the wrong axis.

## Changes

- Add \`FusionWeights.vector: f32\` (with \`#[serde(default = \"default_vector_weight\")]\` — existing TOML configs keep parsing).
- Fix \`policy_from_config\` mapping to match \`RetrievalSource::{Vector, Keyword, Graph}\`:
  - \`vector_weight ← weights.vector\`
  - \`keyword_weight ← weights.keywords\`
  - \`graph_weight ← weights.graph\`
- Mark \`bm25\` field deprecated in doc comment (BM25 *is* the keyword retriever — its weight belongs in the keyword axis). Field retained for back-compat.
- Default weights rebalanced: \`{vector: 0.4, keywords: 0.2, graph: 0.4, bm25: 0.0}\` — same *effective* weights as before per source, just expressed against correct field names.
- Update two demo example sites to include the new field.

## Behavior change

Any caller that explicitly constructed \`FusionWeights { keywords: X, graph: Y, bm25: Z }\` was getting \`effective vector_weight = X, keyword_weight = Z, graph_weight = Y\`. After this PR, the same struct fields now route to their named axes — net behavior matches what the field names always implied. Callers relying on the old swap should re-balance against the corrected axis.

## Test plan

- [x] \`cargo test -p graphrag-core --lib retrieval::fusion\` — 4 pass
- [x] \`cargo check --workspace --all-targets\` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)